### PR TITLE
fix bugs in gpio service

### DIFF
--- a/examples/app_control_tuning/src/main.xc
+++ b/examples/app_control_tuning/src/main.xc
@@ -201,6 +201,11 @@ int main(void) {
 
                     position_feedback_config.hall_config.port_number = HALL_SENSOR_PORT_NUMBER;
 
+                    position_feedback_config.gpio_config[0] = GPIO_OFF;
+                    position_feedback_config.gpio_config[1] = GPIO_OFF;
+                    position_feedback_config.gpio_config[2] = GPIO_OFF;
+                    position_feedback_config.gpio_config[3] = GPIO_OFF;
+
                     //setting second sensor
                     PositionFeedbackConfig position_feedback_config_2 = position_feedback_config;
                     position_feedback_config_2.sensor_type = 0;

--- a/examples/app_demo_motion_control/src/main.xc
+++ b/examples/app_demo_motion_control/src/main.xc
@@ -201,6 +201,11 @@ int main(void) {
 
                     position_feedback_config.hall_config.port_number = HALL_SENSOR_PORT_NUMBER;
 
+                    position_feedback_config.gpio_config[0] = GPIO_OFF;
+                    position_feedback_config.gpio_config[1] = GPIO_OFF;
+                    position_feedback_config.gpio_config[2] = GPIO_OFF;
+                    position_feedback_config.gpio_config[3] = GPIO_OFF;
+
                     //setting second sensor
                     PositionFeedbackConfig position_feedback_config_2 = position_feedback_config;
                     position_feedback_config_2.sensor_type = 0;

--- a/examples/app_demo_torque_control/src/main.xc
+++ b/examples/app_demo_torque_control/src/main.xc
@@ -154,6 +154,11 @@ int main(void) {
 
                     position_feedback_config.hall_config.port_number = HALL_SENSOR_PORT_NUMBER;
 
+                    position_feedback_config.gpio_config[0] = GPIO_OFF;
+                    position_feedback_config.gpio_config[1] = GPIO_OFF;
+                    position_feedback_config.gpio_config[2] = GPIO_OFF;
+                    position_feedback_config.gpio_config[3] = GPIO_OFF;
+
                     //setting second sensor
                     PositionFeedbackConfig position_feedback_config_2 = position_feedback_config;
                     position_feedback_config_2.sensor_type = 0;

--- a/examples/app_test_position_feedback/config.xscope
+++ b/examples/app_test_position_feedback/config.xscope
@@ -29,6 +29,9 @@
     <Probe name="Angle Shared Memory" type="CONTINUOUS" datatype="INT" units="Value" enabled="true"/>
     <Probe name="Velocity Shared Memory" type="CONTINUOUS" datatype="INT" units="Value" enabled="true"/>
     <Probe name="GPIO 0" type="CONTINUOUS" datatype="INT" units="Value" enabled="true"/>
+    <Probe name="GPIO 1" type="CONTINUOUS" datatype="INT" units="Value" enabled="false"/>
+    <Probe name="GPIO 2" type="CONTINUOUS" datatype="INT" units="Value" enabled="true"/>
+    <Probe name="GPIO 3" type="CONTINUOUS" datatype="INT" units="Value" enabled="false"/>
     
 
 </xSCOPEconfig>

--- a/examples/app_test_position_feedback/src/main.xc
+++ b/examples/app_test_position_feedback/src/main.xc
@@ -45,11 +45,12 @@ void position_feedback_display(client interface PositionFeedbackInterface i_posi
             xscope_int(VELOCITY_SHARED_MEMORY, upstream_control_data.velocity);
 
             //write gpio
-            unsigned int gpio_out = 0b1010;
+            unsigned int gpio_out = 0b0010; // we write 1 to the port 1 and 0 to the port 3, port 0 and 2 are in read mode
             i_shared_memory.write_gpio_output(gpio_out);
 
             //read gpio
             xscope_int(GPIO_0, 1000 * upstream_control_data.gpio[0]);
+            xscope_int(GPIO_2, 1000 * upstream_control_data.gpio[2]);
         }
 
         xscope_int(POSITION_1, position_1);
@@ -254,9 +255,9 @@ int main(void)
 
                 position_feedback_config_1.hall_config.port_number = HALL_SENSOR_PORT_NUMBER;
 
-                position_feedback_config_1.gpio_config[0] = GPIO_INPUT_PULLDOWN;
+                position_feedback_config_1.gpio_config[0] = GPIO_INPUT;
                 position_feedback_config_1.gpio_config[1] = GPIO_OUTPUT;
-                position_feedback_config_1.gpio_config[2] = GPIO_OUTPUT;
+                position_feedback_config_1.gpio_config[2] = GPIO_INPUT_PULLDOWN;
                 position_feedback_config_1.gpio_config[3] = GPIO_OUTPUT;
 
                 PositionFeedbackConfig position_feedback_config_2;

--- a/module_hall_sensor/include/hall_service.h
+++ b/module_hall_sensor/include/hall_service.h
@@ -19,9 +19,11 @@
  * @param position_feedback_config Configuration for the service.
  * @param i_shared_memory Client interface to write the position data to the shared memory.
  * @param i_position_feedback Server interface used by clients for configuration and direct position read.
+ * @param gpio_on Set to 1 to enable GPIO read/write.
  */
 void hall_service(QEIHallPort &qei_hall_port, port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedback_config,
                   client interface shared_memory_interface ?i_shared_memory,
-                  server interface PositionFeedbackInterface i_position_feedback[3]);
+                  server interface PositionFeedbackInterface i_position_feedback[3],
+                  int gpio_on);
 
 #endif

--- a/module_hall_sensor/src/hall_service.xc
+++ b/module_hall_sensor/src/hall_service.xc
@@ -84,7 +84,8 @@ static const unsigned int hall_half_angle[6] = {
 
 void hall_service(QEIHallPort &qei_hall_port, port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedback_config,
         client interface shared_memory_interface ?i_shared_memory,
-                server interface PositionFeedbackInterface i_position_feedback[3])
+                server interface PositionFeedbackInterface i_position_feedback[3],
+                int gpio_on)
 {
 
 #ifdef DEBUG_POSITION_FEEDBACK
@@ -428,7 +429,7 @@ void hall_service(QEIHallPort &qei_hall_port, port * (&?gpio_ports)[4], Position
                 write_shared_memory(i_shared_memory, position_feedback_config.sensor_function, count + position_feedback_config.offset, speed_out, angle_out, hall_state_new, SENSOR_NO_ERROR, SENSOR_NO_ERROR, time1/position_feedback_config.ifm_usec);
 
                 //gpio
-                gpio_shared_memory(gpio_ports, position_feedback_config, i_shared_memory);
+                gpio_shared_memory(gpio_ports, position_feedback_config, i_shared_memory, gpio_on);
 
 
                 tx :> time1;

--- a/module_incremental_encoder/include/qei_service.h
+++ b/module_incremental_encoder/include/qei_service.h
@@ -19,9 +19,11 @@
  * @param position_feedback_config Configuration for the service.
  * @param i_shared_memory Client interface to write the position data to the shared memory.
  * @param i_position_feedback Server interface used by clients for configuration and direct position read.
+ * @param gpio_on Set to 1 to enable GPIO read/write.
  */
 void qei_service(QEIHallPort &qei_hall_port, port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedback_config,
                  client interface shared_memory_interface ?i_shared_memory,
-                 server interface PositionFeedbackInterface i_position_feedback[3]);
+                 server interface PositionFeedbackInterface i_position_feedback[3],
+                 int gpio_on);
 
 #endif

--- a/module_incremental_encoder/src/qei_service.xc
+++ b/module_incremental_encoder/src/qei_service.xc
@@ -58,7 +58,8 @@ int check_qei_config(PositionFeedbackConfig &position_feedback_config)
 #pragma unsafe arrays
 void qei_service(QEIHallPort &qei_hall_port, port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedback_config,
                  client interface shared_memory_interface ?i_shared_memory,
-                 server interface PositionFeedbackInterface i_position_feedback[3])
+                 server interface PositionFeedbackInterface i_position_feedback[3],
+                 int gpio_on)
 {
 
 #ifdef DEBUG_POSITION_FEEDBACK
@@ -284,7 +285,7 @@ void qei_service(QEIHallPort &qei_hall_port, port * (&?gpio_ports)[4], PositionF
                 write_shared_memory(i_shared_memory, position_feedback_config.sensor_function, count + position_feedback_config.offset, velocity, 0, 0, SENSOR_NO_ERROR, SENSOR_NO_ERROR, ts_velocity/position_feedback_config.ifm_usec);
 
                 //gpio
-                gpio_shared_memory(gpio_ports, position_feedback_config, i_shared_memory);
+                gpio_shared_memory(gpio_ports, position_feedback_config, i_shared_memory, gpio_on);
 
                 break;
 

--- a/module_position_feedback/include/position_feedback_service.h
+++ b/module_position_feedback/include/position_feedback_service.h
@@ -26,7 +26,8 @@
  * @brief GPIO port type
  */
 typedef enum {
-    GPIO_INPUT=0,           /**< Input GPIO port */
+    GPIO_OFF=0,             /**< GPIO port off */
+    GPIO_INPUT,             /**< Input GPIO port */
     GPIO_INPUT_PULLDOWN,    /**< Input GPIO port with pulldown */
     GPIO_OUTPUT             /**< Output GPIO port */
 } GPIOType;
@@ -326,8 +327,9 @@ void gpio_write(port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedb
  * @param gpio_ports The GPIO ports array
  * @param position_feedback_config The position feedback service configuration
  * @param i_shared_memory The client interface to the shared memory
+ * @param service_number Service number (1 or 2) use to enable GPIO only on 1.
  */
-void gpio_shared_memory(port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedback_config, client interface shared_memory_interface ?i_shared_memory);
+void gpio_shared_memory(port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedback_config, client interface shared_memory_interface ?i_shared_memory, int service_number);
 
 
 #endif

--- a/module_position_feedback/src/position_feedback_service.xc
+++ b/module_position_feedback/src/position_feedback_service.xc
@@ -17,7 +17,8 @@ char start_message[] = ">>   SOMANET SENSOR SERVICE STARTING: ";
 
 void fallback_service(port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedback_config,
                       client interface shared_memory_interface ?i_shared_memory,
-                      server interface PositionFeedbackInterface i_position_feedback[3])
+                      server interface PositionFeedbackInterface i_position_feedback[3],
+                      int gpio_on)
 {
 #ifdef DEBUG_POSITION_FEEDBACK
     printstr(start_message);
@@ -77,7 +78,7 @@ void fallback_service(port * (&?gpio_ports)[4], PositionFeedbackConfig &position
 
         //gpio
         case t when timerafter(ts + (1000*position_feedback_config.ifm_usec)) :> ts:
-                gpio_shared_memory(gpio_ports, position_feedback_config, i_shared_memory);
+                gpio_shared_memory(gpio_ports, position_feedback_config, i_shared_memory, gpio_on);
                 break;
         }
     }
@@ -87,30 +88,31 @@ void start_service(QEIHallPort * qei_hall_port_1, QEIHallPort * qei_hall_port_2,
                    int hall_enc_select_config,
                    PositionFeedbackConfig &position_feedback_config,
                    client interface shared_memory_interface ?i_shared_memory,
-                   server interface PositionFeedbackInterface i_position_feedback[3])
+                   server interface PositionFeedbackInterface i_position_feedback[3],
+                   int gpio_on)
 {
     switch(position_feedback_config.sensor_type) {
     case BISS_SENSOR:
     case REM_16MT_SENSOR:
     case REM_14_SENSOR:
-        serial_encoder_service(qei_hall_port_1, qei_hall_port_2, hall_enc_select_port, spi_ports, gpio_ports, hall_enc_select_config, position_feedback_config, i_shared_memory, i_position_feedback);
+        serial_encoder_service(qei_hall_port_1, qei_hall_port_2, hall_enc_select_port, spi_ports, gpio_ports, hall_enc_select_config, position_feedback_config, i_shared_memory, i_position_feedback, gpio_on);
         break;
     case HALL_SENSOR:
         if (position_feedback_config.hall_config.port_number == ENCODER_PORT_1) {
-            hall_service(*qei_hall_port_1, gpio_ports, position_feedback_config, i_shared_memory, i_position_feedback);
+            hall_service(*qei_hall_port_1, gpio_ports, position_feedback_config, i_shared_memory, i_position_feedback, gpio_on);
         } else if (position_feedback_config.hall_config.port_number == ENCODER_PORT_2) {
-            hall_service(*qei_hall_port_2, gpio_ports, position_feedback_config, i_shared_memory, i_position_feedback);
+            hall_service(*qei_hall_port_2, gpio_ports, position_feedback_config, i_shared_memory, i_position_feedback, gpio_on);
         }
         break;
     case QEI_SENSOR:
         if (position_feedback_config.qei_config.port_number == ENCODER_PORT_1) {
-            qei_service(*qei_hall_port_1, gpio_ports, position_feedback_config, i_shared_memory, i_position_feedback);
+            qei_service(*qei_hall_port_1, gpio_ports, position_feedback_config, i_shared_memory, i_position_feedback, gpio_on);
         } else if (position_feedback_config.qei_config.port_number == ENCODER_PORT_2) {
-            qei_service(*qei_hall_port_2, gpio_ports, position_feedback_config, i_shared_memory, i_position_feedback);
+            qei_service(*qei_hall_port_2, gpio_ports, position_feedback_config, i_shared_memory, i_position_feedback, gpio_on);
         }
         break;
     default:
-        fallback_service(gpio_ports, position_feedback_config, i_shared_memory, i_position_feedback);
+        fallback_service(gpio_ports, position_feedback_config, i_shared_memory, i_position_feedback, gpio_on);
         break;
     }
 }
@@ -184,6 +186,7 @@ void check_ports(QEIHallPort * qei_hall_port_1, QEIHallPort * qei_hall_port_2, H
                 } else {
                     set_port_use_on(*gpio_ports[position_feedback_config.biss_config.clock_port_config]);
                     configure_out_port(*gpio_ports[position_feedback_config.biss_config.clock_port_config], (*spi_ports).spi_interface.blk1, 1);
+                    position_feedback_config.gpio_config[position_feedback_config.biss_config.clock_port_config] = GPIO_OFF; //disable GPIO on this port
                 }
             }
             //configure clock rate
@@ -293,9 +296,9 @@ void gpio_write(port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedb
     }
 }
 
-void gpio_shared_memory(port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedback_config, client interface shared_memory_interface ?i_shared_memory)
+void gpio_shared_memory(port * (&?gpio_ports)[4], PositionFeedbackConfig &position_feedback_config, client interface shared_memory_interface ?i_shared_memory, int gpio_on)
 {
-    if (!isnull(gpio_ports) && !isnull(i_shared_memory)) {
+    if (gpio_on == 1 && !isnull(i_shared_memory)) {
         unsigned int gpio_input = 0;
         for (int i=0 ; i<4 ; i++) {
             if ( gpio_ports[i] != null &&
@@ -439,24 +442,15 @@ void position_feedback_service(QEIHallPort &?qei_hall_port_1, QEIHallPort &?qei_
                 spi_on = 1;
             }
         }
-        if (!spi_on && gpio_ports_check) {
-            for (int i=0 ; i<NUMBER_OF_GPIO_PORTS ; i++) {
-                if (position_feedback_config_1.gpio_config[i] == GPIO_INPUT_PULLDOWN) {
-                    set_port_pull_down(*gpio_ports[i]);
-                } else {
-                    set_port_pull_none(*gpio_ports[i]);
-                }
-            }
-        }
 
         //start services
         par {
             {//sensor 1
-                start_service(qei_hall_port_1_1, qei_hall_port_2_1, hall_enc_select_port_1, spi_ports_1, gpio_ports, hall_enc_select_config, position_feedback_config_1, i_shared_memory_1, i_position_feedback_1);
+                start_service(qei_hall_port_1_1, qei_hall_port_2_1, hall_enc_select_port_1, spi_ports_1, gpio_ports, hall_enc_select_config, position_feedback_config_1, i_shared_memory_1, i_position_feedback_1, 1);
             }
             {//sensor 2
                 if (!isnull(i_position_feedback_2) && !isnull(position_feedback_config_2)) {
-                    start_service(qei_hall_port_1_2, qei_hall_port_2_2, hall_enc_select_port_2, spi_ports_2, gpio_ports_2, hall_enc_select_config, position_feedback_config_2, i_shared_memory_2, i_position_feedback_2);
+                    start_service(qei_hall_port_1_2, qei_hall_port_2_2, hall_enc_select_port_2, spi_ports_2, gpio_ports_2, hall_enc_select_config, position_feedback_config_2, i_shared_memory_2, i_position_feedback_2, 0);
                 }
             }
         }

--- a/module_serial_encoder/include/serial_encoder_service.h
+++ b/module_serial_encoder/include/serial_encoder_service.h
@@ -23,7 +23,11 @@
  * @param position_feedback_config Configuration for the service.
  * @param i_shared_memory Client interface to write the position data to the shared memory.
  * @param i_position_feedback Server interface used by clients for configuration and direct position read.
+ * @param gpio_on Set to 1 to enable GPIO read/write.
  */
-void serial_encoder_service(QEIHallPort * qei_hall_port_1, QEIHallPort * qei_hall_port_2, HallEncSelectPort * hall_enc_select_port, SPIPorts * spi_ports, port * (&?gpio_ports)[4], int hall_enc_select_config, PositionFeedbackConfig &position_feedback_config, client interface shared_memory_interface ?i_shared_memory, interface PositionFeedbackInterface server i_position_feedback[3]);
-
+void serial_encoder_service(QEIHallPort * qei_hall_port_1, QEIHallPort * qei_hall_port_2, HallEncSelectPort * hall_enc_select_port, SPIPorts * spi_ports, port * (&?gpio_ports)[4],
+                int hall_enc_select_config, PositionFeedbackConfig &position_feedback_config,
+                client interface shared_memory_interface ?i_shared_memory,
+                interface PositionFeedbackInterface server i_position_feedback[3],
+                int gpio_on);
 #endif

--- a/module_serial_encoder/src/serial_encoder_service.xc
+++ b/module_serial_encoder/src/serial_encoder_service.xc
@@ -162,7 +162,11 @@ int init_sensor(QEIHallPort * qei_hall_port_1, QEIHallPort * qei_hall_port_2, Ha
 }
 
 
-void serial_encoder_service(QEIHallPort * qei_hall_port_1, QEIHallPort * qei_hall_port_2, HallEncSelectPort * hall_enc_select_port, SPIPorts * spi_ports, port * (&?gpio_ports)[4], int hall_enc_select_config, PositionFeedbackConfig &position_feedback_config, client interface shared_memory_interface ?i_shared_memory, interface PositionFeedbackInterface server i_position_feedback[3])
+void serial_encoder_service(QEIHallPort * qei_hall_port_1, QEIHallPort * qei_hall_port_2, HallEncSelectPort * hall_enc_select_port, SPIPorts * spi_ports, port * (&?gpio_ports)[4],
+                int hall_enc_select_config, PositionFeedbackConfig &position_feedback_config,
+                client interface shared_memory_interface ?i_shared_memory,
+                interface PositionFeedbackInterface server i_position_feedback[3],
+                int gpio_on)
 {
 
     //init variables
@@ -362,7 +366,7 @@ void serial_encoder_service(QEIHallPort * qei_hall_port_1, QEIHallPort * qei_hal
             write_shared_memory(i_shared_memory, position_feedback_config.sensor_function, pos_state.count + position_feedback_config.offset, velocity, pos_state.angle, 0, pos_state.status, last_sensor_error, last_read/position_feedback_config.ifm_usec);
 
             //gpio
-            gpio_shared_memory(gpio_ports, position_feedback_config, i_shared_memory);
+            gpio_shared_memory(gpio_ports, position_feedback_config, i_shared_memory, gpio_on);
 
 
             //compute next loop time


### PR DESCRIPTION
- only use gpio on the first position_feedback_service
- fix gpio ports config inside position_feedback_service
- disable gpio port when used by BiSS
- disable gpio service in motorcontrol demo apps