### PR TITLE
fix qei index type enum to use 2 for two channels (AB) and 3 for thre…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,16 +1,22 @@
 sc_sncn_motorcontrol Change Log
 ===============================
 
+3.0.3
+-----
+
+  * Fix value of Encoder Number of Channels to 2 for AB and 3 for ABI.
+
+
 3.0.2
 -----
 
   * Rename MOTOR_PHASES_CONFIGURATION in user_config.h and main.xc files.
   * Fix position control strategy values: POS_PID_CONTROLLER = 1, POS_PID_VELOCITY_CASCADED_CONTROLLER = 2, NL_POSITION_CONTROLLER = 3, VELOCITY_PID_CONTROLLER = 4
   * Fix bug in gpio service:
-   * only use gpio on the first position_feedback_service
-   * fix gpio ports config inside position_feedback_service
-   * disable gpio port when used by BiSS
-   * disable gpio service in motorcontrol demo apps
+  * only use gpio on the first position_feedback_service
+  * fix gpio ports config inside position_feedback_service
+  * disable gpio port when used by BiSS
+  * disable gpio service in motorcontrol demo apps
   * Fix BiSS multiturn with inverted sensor polarity
   * Fix sensor polarity in sensor test apps
 

--- a/module_incremental_encoder/include/qei_struct.h
+++ b/module_incremental_encoder/include/qei_struct.h
@@ -42,10 +42,13 @@ typedef enum {
 
 /**
  * @brief Type for the sort of Encoder index.
+ *
+ * 2 is for two signals A and B
+ * 3 is for three signals A, B and I for index
  */
 typedef enum {
-    QEI_WITH_NO_INDEX,  /**< Encoder with no index signal. */
-    QEI_WITH_INDEX      /**< Encoder with index signal.  */
+    QEI_WITH_NO_INDEX = 2,  /**< Encoder with no index signal. */
+    QEI_WITH_INDEX    = 3   /**< Encoder with index signal. */
 } QEI_IndexType;
 
 


### PR DESCRIPTION
Fix qei index type enum to use 2 for two channels (AB) and 3 for three channels (ABI)
Those values are more natural when used in ethercat drive sdo parameters.