### PR TITLE
Add initialisation of the cogging torque parameters to the applications

### DIFF
--- a/examples/app_demo_motion_control/src/main.xc
+++ b/examples/app_demo_motion_control/src/main.xc
@@ -82,6 +82,7 @@ int main(void) {
             motion_ctrl_config.velocity_kd =                          VELOCITY_Kd;
             motion_ctrl_config.velocity_integral_limit =              VELOCITY_INTEGRAL_LIMIT;
             motion_ctrl_config.enable_velocity_auto_tuner =           ENABLE_VELOCITY_AUTO_TUNER;
+            motion_ctrl_config.enable_compensation_recording =        ENABLE_COMPENSATION_RECORDING;
 
             motion_ctrl_config.brake_release_strategy =               BRAKE_RELEASE_STRATEGY;
             motion_ctrl_config.brake_release_delay =                  BRAKE_RELEASE_DELAY;
@@ -155,7 +156,10 @@ int main(void) {
                     motorcontrol_config.protection_limit_over_voltage =  PROTECTION_MAXIMUM_VOLTAGE;
                     motorcontrol_config.protection_limit_under_voltage = PROTECTION_MINIMUM_VOLTAGE;
                     motorcontrol_config.protection_limit_over_temperature = TEMP_BOARD_MAX;
-
+                    for (int i = 0; i < 1024; i++)
+                    {
+                        motorcontrol_config.torque_offset[i] = 0;
+                    }
                     torque_control_service(motorcontrol_config, i_adc[0], i_shared_memory[2],
                             i_watchdog[0], i_torque_control, i_update_pwm, IFM_TILE_USEC);
                 }

--- a/examples/app_demo_torque_control/src/main.xc
+++ b/examples/app_demo_torque_control/src/main.xc
@@ -105,6 +105,10 @@ int main(void) {
                     motorcontrol_config.protection_limit_over_voltage =  PROTECTION_MAXIMUM_VOLTAGE;
                     motorcontrol_config.protection_limit_under_voltage = PROTECTION_MINIMUM_VOLTAGE;
                     motorcontrol_config.protection_limit_over_temperature = TEMP_BOARD_MAX;
+                    for (int i = 0; i < 1024; i++)
+                    {
+                        motorcontrol_config.torque_offset[i] = 0;
+                    }
 
                     torque_control_service(motorcontrol_config, i_adc[0], i_shared_memory[2],
                             i_watchdog[0], i_torque_control, i_update_pwm, IFM_TILE_USEC);

--- a/examples/app_test_rem_16mt_encoder/src/main.xc
+++ b/examples/app_test_rem_16mt_encoder/src/main.xc
@@ -247,6 +247,10 @@ int main(void)
                 motorcontrol_config.protection_limit_over_voltage =  PROTECTION_MAXIMUM_VOLTAGE;
                 motorcontrol_config.protection_limit_under_voltage = PROTECTION_MINIMUM_VOLTAGE;
                 motorcontrol_config.protection_limit_over_temperature = TEMP_BOARD_MAX;
+                for (int i = 0; i < 1024; i++)
+                {
+                    motorcontrol_config.torque_offset[i] = 0;
+                }
 
                 torque_control_service(motorcontrol_config, i_adc[0], i_shared_memory[1],
                         i_watchdog[0], i_torque_control, i_update_pwm, IFM_TILE_USEC);


### PR DESCRIPTION
To avoid having the calibration on startup it is necessary to put the cogging torque parameters to 0 when the control starts