### PR TITLE
Correct bugs cogging torque

### DIFF
--- a/examples/app_control_tuning/src/tuning_console.xc
+++ b/examples/app_control_tuning/src/tuning_console.xc
@@ -137,14 +137,6 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         motion_ctrl_config = i_motion_control.get_motion_control_config();
                         motion_ctrl_config.enable_compensation_recording = 1;
                         i_motion_control.set_motion_control_config(motion_ctrl_config);
-//
-//                        while (motion_ctrl_config.enable_compensation_recording)
-//                        {
-//                            motion_ctrl_config = i_motion_control.get_motion_control_config();
-//                            delay_milliseconds(1);
-//                        }
-//                        i_motion_control.disable();
-//                        printf("Cogging torque calibrated\n");
                         break;
 
                 case 'v'://calculate optimal pid parameters for velocity controller

--- a/examples/app_control_tuning/src/tuning_console.xc
+++ b/examples/app_control_tuning/src/tuning_console.xc
@@ -137,14 +137,14 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         motion_ctrl_config = i_motion_control.get_motion_control_config();
                         motion_ctrl_config.enable_compensation_recording = 1;
                         i_motion_control.set_motion_control_config(motion_ctrl_config);
-
-                        while (motion_ctrl_config.enable_compensation_recording)
-                        {
-                            motion_ctrl_config = i_motion_control.get_motion_control_config();
-                            delay_milliseconds(1);
-                        }
-                        i_motion_control.disable();
-                        printf("Cogging torque calibrated\n");
+//
+//                        while (motion_ctrl_config.enable_compensation_recording)
+//                        {
+//                            motion_ctrl_config = i_motion_control.get_motion_control_config();
+//                            delay_milliseconds(1);
+//                        }
+//                        i_motion_control.disable();
+//                        printf("Cogging torque calibrated\n");
                         break;
 
                 case 'v'://calculate optimal pid parameters for velocity controller

--- a/module_motion_control/doc/index.rst
+++ b/module_motion_control/doc/index.rst
@@ -324,6 +324,16 @@ How to use
 
 3-	At the end of the measurement process, the variable **enable_compensation_recording** is automatically set to 0. You can then enable/disable the compensation of the cogging torque with the interface enable_cogging_compensation()
 
+.. warning ::
+
+	Warning
+	-------
+	Before the calibration process, make sure that the velocity PID parameters are set for a stable control at 10 RPM
+	To tune the controller, feel free to use the :ref:`Tuning application <app_control_tuning>`. (Bad tuning means the motor turns visibly step by step, stopping from time to time)
+
+	Once the cogging torque is calibrated for a motor, it is saved in the memory. It is possible to enable/disable the compensation without doing the calibration another time. 
+
+	Before doing the calibration, be sure that the compensation is disabled, otherwise the measures will be altered.
 
 Example
 -------
@@ -359,12 +369,3 @@ Example
             downstream_control_data.torque_cmd = 0;
 
         }
-
-Warning
--------
-Before the calibration process, make sure that the velocity PID parameters are set for a stable control at 10 RPM
-To tune the controller, feel free to use the :ref:`Tuning application <app_control_tuning>`.
-
-Once the cogging torque is calibrated for a motor, it is saved in the memory. It is possible to enable/disable the compensation without doing the calibration another time. 
-
-Before doing the calibration, be sure that the compensation is disabled, otherwise the measures will be altered.

--- a/module_motion_control/src/motion_control_service.xc
+++ b/module_motion_control/src/motion_control_service.xc
@@ -608,6 +608,12 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
 
                 upstream_control_data = i_torque_control.update_upstream_control_data();
 
+
+                if (motion_ctrl_config.enable_compensation_recording)
+                {
+                    downstream_control_data.velocity_cmd = ct_parameters.velocity_reference;
+                }
+
                 velocity_ref_k    = ((double) downstream_control_data.velocity_cmd);
                 velocity_k        = ((double) upstream_control_data.velocity);
 
@@ -742,6 +748,15 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                                 ct_parameters.torque_recording_started = 0;
                                 ct_parameters.delay_counter = 0;
                                 i_torque_control.set_torque_control_enabled();
+                                i_torque_control.set_brake_status(0);
+
+                                if(ct_parameters.back_and_forth == 2)
+                                {
+                                    torque_enable_flag   =0;
+                                    velocity_enable_flag =0;
+                                    position_enable_flag =0;
+                                    i_torque_control.set_torque_control_disabled();
+                                }
                             }
                         }
                         else

--- a/module_motion_control/src/motion_control_service.xc
+++ b/module_motion_control/src/motion_control_service.xc
@@ -739,7 +739,6 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                                         ct_parameters.torque_recording[i]= 0;
                                     }
                                     ct_parameters.rotation_sign = 0;
-                                    ct_parameters.back_and_forth = 0;
                                     motion_ctrl_config.enable_compensation_recording = 0;
                                     velocity_ref_k = 0;
                                 }
@@ -752,6 +751,7 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
 
                                 if(ct_parameters.back_and_forth == 2)
                                 {
+                                    ct_parameters.back_and_forth = 0;
                                     torque_enable_flag   =0;
                                     velocity_enable_flag =0;
                                     position_enable_flag =0;
@@ -1261,7 +1261,10 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                     torque_enable_flag   =0;
                     velocity_enable_flag =0;
                     position_enable_flag =0;
+                    motion_ctrl_config.enable_compensation_recording = 0;
+                    init_cogging_torque_parameters(ct_parameters, 10);
                     i_torque_control.set_torque_control_disabled();
+
                 }
 
                 motion_ctrl_config.position_control_autotune =0;


### PR DESCRIPTION
The cogging torque record command doesn't block the process while waiting for it to finish, which enables the user to stop it if something is wrong (the motor doesn't turn).