### PR TITLE
Fix BiSS CRC computation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ sc_sncn_motorcontrol Change Log
   * Fix Hall service position initialization.
   * Fix integral issue in PID controllers (Reset integral value in case new ki is 0).
   * Do not change the integral limits of position/velocity controllers in case automatic tuners are called
+  * Fix BiSS CRC computation
 
 3.0.2
 -----

--- a/module_biss_encoder/include/biss_service.h
+++ b/module_biss_encoder/include/biss_service.h
@@ -44,7 +44,7 @@ SensorError read_biss_sensor_data(QEIHallPort * qei_hall_port_1, QEIHallPort * q
  *
  * @param data BiSS data
  * @param data_length length of data in bits
- * @param crc_poly crc polynomial in reverse representation:  x^0 + x^1 + x^4 is 0b1100
+ * @param crc_poly crc polynomial in reverse representation with high exponent omitted:  x^0 + x^1 + x^6 is 0b110000
  *
  * @return inverted crc for BiSS
  */


### PR DESCRIPTION
The previous function had a bug when data was bigger than 1 byte (32 bit).