### PR TITLE
Fix qei commutation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ sc_sncn_motorcontrol Change Log
 -----
 
   * Integrate GPIO service in ethercat drive enabled for SDK 3.0.4
+  * Fix Incremental encoder position update to the shared memory
 
 
 3.1

--- a/examples/app_test_incremental_encoder/src/main.xc
+++ b/examples/app_test_incremental_encoder/src/main.xc
@@ -66,6 +66,7 @@ int main(void)
                 position_feedback_config.resolution  = QEI_SENSOR_RESOLUTION;
                 position_feedback_config.ifm_usec    = IFM_TILE_USEC;
                 position_feedback_config.max_ticks   = SENSOR_MAX_TICKS;
+                position_feedback_config.offset      = HOME_OFFSET;
                 position_feedback_config.velocity_compute_period = QEI_SENSOR_VELOCITY_COMPUTE_PERIOD;
                 position_feedback_config.sensor_function = SENSOR_FUNCTION_COMMUTATION_AND_MOTION_CONTROL;
 

--- a/module_incremental_encoder/src/qei_service.xc
+++ b/module_incremental_encoder/src/qei_service.xc
@@ -144,9 +144,6 @@ void qei_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedbackC
                                     losing_ticks_counter = 0;
                             }
 
-//                            if (align != 0)
-//                                last_sensor_error = 16000 - align;
-
 
                             if ((align < (position_feedback_config.resolution/2)) && (align > (-position_feedback_config.resolution/2))) {
                                 count -= align;
@@ -164,6 +161,9 @@ void qei_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedbackC
                         }
 
                         angle = ((position * position_feedback_config.pole_pairs* (1<<12))/ position_feedback_config.resolution) & ((1<<12)-1);
+                        unsigned int timestamp;
+                        t_velocity :> timestamp;
+                        write_shared_memory(i_shared_memory, position_feedback_config.sensor_function, count + position_feedback_config.offset, position * (1 << (16 - shift_counter)) / shift, velocity, angle, 0, index_found, sensor_error, last_sensor_error, ts_velocity/ifm_usec);
                     }
                 }
                 break;

--- a/module_incremental_encoder/src/qei_service.xc
+++ b/module_incremental_encoder/src/qei_service.xc
@@ -163,7 +163,7 @@ void qei_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedbackC
                         angle = ((position * position_feedback_config.pole_pairs* (1<<12))/ position_feedback_config.resolution) & ((1<<12)-1);
                         unsigned int timestamp;
                         t_velocity :> timestamp;
-                        write_shared_memory(i_shared_memory, position_feedback_config.sensor_function, count + position_feedback_config.offset, position * (1 << (16 - shift_counter)) / shift, velocity, angle, 0, index_found, sensor_error, last_sensor_error, ts_velocity/ifm_usec);
+                        write_shared_memory(i_shared_memory, position_feedback_config.sensor_function, count + position_feedback_config.offset, position * (1 << (16 - shift_counter)) / shift, velocity, angle, 0, index_found, sensor_error, last_sensor_error, timestamp/ifm_usec);
                     }
                 }
                 break;


### PR DESCRIPTION
Now the position is sent to the shared memory at every tick and not only after velocity computation.