### PR TITLE
Fix qei hall counter

### DIFF
--- a/module_hall_sensor/src/hall_service.xc
+++ b/module_hall_sensor/src/hall_service.xc
@@ -173,7 +173,6 @@ void hall_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedback
     hall_state_old = hall_state_1;
 
     SensorError sensor_error = SENSOR_NO_ERROR, last_sensor_error = SENSOR_NO_ERROR;
-    int hall_error_counter = 0;
 
     tx :> time1;
 
@@ -193,7 +192,7 @@ void hall_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedback
         case i_position_feedback[int i].get_position() -> { int out_count, unsigned int out_position, SensorError status }:
                 out_count = count;
                 out_position = singleturn;
-                status = SENSOR_NO_ERROR;
+                status = sensor_error;
                 break;
 
         case i_position_feedback[int i].get_velocity() -> int out_velocity:
@@ -212,7 +211,6 @@ void hall_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedback
         case i_position_feedback[int i].set_config(PositionFeedbackConfig in_config):
                 sensor_error = SENSOR_NO_ERROR;
                 last_sensor_error = SENSOR_NO_ERROR;
-                hall_error_counter = 0;
                 UsecType ifm_usec = position_feedback_config.ifm_usec;
                 position_feedback_config = in_config;
                 singleturn_resolution = (1 << 12) * position_feedback_config.pole_pairs;
@@ -301,45 +299,30 @@ void hall_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedback
                         {
                         case 1:
                             if (hall_state_new != 5 && hall_state_new != 3)
-                                ++hall_error_counter;
-                            else
-                                hall_error_counter = 0;
+                                sensor_error = SENSOR_HALL_FAULT;
                             break;
                         case 2:
                             if (hall_state_new != 3 && hall_state_new != 6)
-                                ++hall_error_counter;
-                            else
-                                hall_error_counter = 0;
+                                sensor_error = SENSOR_HALL_FAULT;
                             break;
                         case 3:
                             if (hall_state_new != 1 && hall_state_new != 2)
-                                ++hall_error_counter;
-                            else
-                                hall_error_counter = 0;
+                                sensor_error = SENSOR_HALL_FAULT;
                             break;
                         case 4:
                             if (hall_state_new != 6 && hall_state_new != 5)
-                                ++hall_error_counter;
-                            else
-                                hall_error_counter = 0;
+                                sensor_error = SENSOR_HALL_FAULT;;
                             break;
                         case 5:
                             if (hall_state_new != 4 && hall_state_new != 1)
-                                ++hall_error_counter;
-                            else
-                                hall_error_counter = 0;
+                                sensor_error = SENSOR_HALL_FAULT;
                             break;
                         case 6:
                             if (hall_state_new != 2 && hall_state_new != 4)
-                                ++hall_error_counter;
-                            else
-                                hall_error_counter = 0;
+                                sensor_error = SENSOR_HALL_FAULT;
                             break;
                         }
                     }
-
-                    if (hall_error_counter == 1000)
-                        sensor_error = SENSOR_HALL_FAULT;
 
                     if (sensor_error != SENSOR_NO_ERROR)
                         last_sensor_error = sensor_error;

--- a/module_hall_sensor/src/hall_service.xc
+++ b/module_hall_sensor/src/hall_service.xc
@@ -117,7 +117,6 @@ void hall_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedback
 
     int angle_out=0, last_angle=0, speed_out=0, count = 0, singleturn = 0;
     int singleturn_resolution = (1 << 12) * position_feedback_config.pole_pairs;
-    int init_angle = 0;
 
     int hall_sector_and_state_temp;
 

--- a/module_incremental_encoder/src/qei_service.xc
+++ b/module_incremental_encoder/src/qei_service.xc
@@ -75,7 +75,7 @@ void qei_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedbackC
     int notification = MOTCTRL_NTF_EMPTY;
 
     SensorError sensor_error = SENSOR_NO_ERROR, last_sensor_error = SENSOR_NO_ERROR;
-    int singleturn_counter = 0, singleturn_old = 0, losing_ticks_counter = 0, ticks_lost;
+    int singleturn_counter = 0, singleturn_old = 0, ticks_lost;
 
     // used to compute the singleturn
     int shift = position_feedback_config.resolution;
@@ -139,9 +139,7 @@ void qei_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedbackC
 
                                 // generate an error
                                 if(ticks_lost > position_feedback_config.resolution/position_feedback_config.qei_config.ticks_lost_threshold)
-                                    ++losing_ticks_counter;
-                                else
-                                    losing_ticks_counter = 0;
+                                    sensor_error = SENSOR_QEI_INDEX_LOSING_TICKS;
                             }
 
 
@@ -261,9 +259,6 @@ void qei_service(port qei_hall_port, port * (&?gpio_ports)[4], PositionFeedbackC
 
                 if (singleturn_counter == 1000)
                     sensor_error = SENSOR_INCREMENTAL_FAULT;
-
-                if (losing_ticks_counter == 1000)
-                    sensor_error = SENSOR_QEI_INDEX_LOSING_TICKS;
 
                 if (sensor_error != SENSOR_NO_ERROR)
                     last_sensor_error = sensor_error;


### PR DESCRIPTION
The Hall service sets the error as soon as there is a missing state change.
Same for the QEI, missing tick per turn threshold sets the error as soon as the ticks are missed.