### PR TITLE
Gain scheduling testing

### DIFF
--- a/examples/app_control_tuning/src/tuning_console.xc
+++ b/examples/app_control_tuning/src/tuning_console.xc
@@ -79,21 +79,35 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
         char mode_3 = 0;
         char mode_4 = 0;
         char c;
-        int value = 0;
+        float value = 0;
         int sign = 1;
+        float decimal_point  = 1;
         //reading user input.
         while((c = getchar ()) != '\n')
         {
+            if(c == '.')
+            {
+                decimal_point = 0.1;
+            }
+
             if(isdigit(c)>0)
             {
-                value *= 10;
-                value += c - '0';
+                if (decimal_point == 1)
+                {
+                    value *= 10;
+                    value += c - '0';
+                }
+                else if (decimal_point < 1)
+                {
+                    value += (c - '0') * decimal_point;
+                    decimal_point /= 10;
+                }
             }
             else if (c == '-')
             {
                 sign = -1;
             }
-            else if (c != ' ')
+            else if (c != ' ' && c != '.')
             {
                 if (mode_1 == 0)
                 {
@@ -595,14 +609,14 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         motion_ctrl_config = i_motion_control.get_motion_control_config();
 
                         if (mode_4 == 0)
-                            printf("Kp:%d Ki:%d Kd:%d j%d i_lim:%d\n",
+                            printf("Kp:%.2f Ki:%.2f Kd:%.2f j%d i_lim:%d\n",
                                     motion_ctrl_config.position_kp, motion_ctrl_config.position_ki, motion_ctrl_config.position_kd,
                                     motion_ctrl_config.moment_of_inertia, motion_ctrl_config.position_integral_limit);
                         else
                         {
-                            printf("Kp_l:%d Ki_l:%d Kd_l:%d i_lim:%d\n",
+                            printf("Kp_l:%.2f Ki_l:%.2f Kd_l:%.2f i_lim:%d\n",
                                     motion_ctrl_config.position_kp_l, motion_ctrl_config.position_ki_l, motion_ctrl_config.position_kd_l, motion_ctrl_config.position_integral_limit);
-                            printf("Kp_h:%d Ki_h:%d Kd_h:%d i_lim:%d\n",
+                            printf("Kp_h:%.2f Ki_h:%.2f Kd_h:%.2f i_lim:%d\n",
                                 motion_ctrl_config.position_kp_h, motion_ctrl_config.position_ki_h, motion_ctrl_config.position_kd_h, motion_ctrl_config.position_integral_limit);
                         }
 
@@ -671,14 +685,14 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         motion_ctrl_config = i_motion_control.get_motion_control_config();
 
                         if(mode_4 == 0)
-                            printf("Kp:%d Ki:%d Kd:%d i_lim:%d\n",
+                            printf("Kp:%.2f Ki:%.2f Kd:%.2f i_lim:%d\n",
                                 motion_ctrl_config.velocity_kp, motion_ctrl_config.velocity_ki, motion_ctrl_config.velocity_kd,
                                 motion_ctrl_config.velocity_integral_limit);
                         else
                         {
-                            printf("Kp_l:%d Ki_l:%d Kd_l:%d i_lim:%d\n",
+                            printf("Kp_l:%.2f Ki_l:%.2f Kd_l:%.2f i_lim:%d\n",
                                     motion_ctrl_config.velocity_kp_l, motion_ctrl_config.velocity_ki_l, motion_ctrl_config.velocity_kd_l, motion_ctrl_config.velocity_integral_limit);
-                        printf("Kp_h:%d Ki_h:%d Kd_h:%d i_lim:%d\n",
+                        printf("Kp_h:%.2f Ki_h:%.2f Kd_h:%.2f i_lim:%d\n",
                                 motion_ctrl_config.velocity_kp_h, motion_ctrl_config.velocity_ki_h, motion_ctrl_config.velocity_kd_h, motion_ctrl_config.velocity_integral_limit);
                         }
 

--- a/examples/app_control_tuning/src/tuning_console.xc
+++ b/examples/app_control_tuning/src/tuning_console.xc
@@ -224,7 +224,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         switch(mode_3)//settings for auto-tuner of position controller
                         {
                         case 'a'://amplitude
-                                motion_ctrl_config.step_amplitude_autotune = value;
+                                motion_ctrl_config.step_amplitude_autotune = (int)value;
 
                                 i_motion_control.set_motion_control_config(motion_ctrl_config);
                                 motion_ctrl_config = i_motion_control.get_motion_control_config();
@@ -233,7 +233,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                                         motion_ctrl_config.per_thousand_overshoot_autotune, motion_ctrl_config.rise_time_freedom_percent_autotune);
                                 break;
                         case 'p'://period
-                                motion_ctrl_config.counter_max_autotune   = value;
+                                motion_ctrl_config.counter_max_autotune   = (int)value;
                                 i_motion_control.set_motion_control_config(motion_ctrl_config);
                                 motion_ctrl_config = i_motion_control.get_motion_control_config();
                                 printf("AutoTuneParams: amplitude %d period(ticks) %d overshoot %d, rise_time %d \n",
@@ -241,7 +241,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                                         motion_ctrl_config.per_thousand_overshoot_autotune, motion_ctrl_config.rise_time_freedom_percent_autotune);
                                 break;
                         case 'o'://overshoot
-                                motion_ctrl_config.per_thousand_overshoot_autotune = value;
+                                motion_ctrl_config.per_thousand_overshoot_autotune = (int)value;
                                 i_motion_control.set_motion_control_config(motion_ctrl_config);
                                 motion_ctrl_config = i_motion_control.get_motion_control_config();
                                 printf("AutoTuneParams: amplitude %d period(ticks) %d overshoot %d, rise_time %d \n",
@@ -249,7 +249,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                                         motion_ctrl_config.per_thousand_overshoot_autotune, motion_ctrl_config.rise_time_freedom_percent_autotune);
                                 break;
                         case 'r'://rise time
-                                motion_ctrl_config.rise_time_freedom_percent_autotune = value;
+                                motion_ctrl_config.rise_time_freedom_percent_autotune = (int)value;
                                 i_motion_control.set_motion_control_config(motion_ctrl_config);
                                 motion_ctrl_config = i_motion_control.get_motion_control_config();
                                 printf("AutoTuneParams: amplitude %d period(ticks) %d overshoot %d, rise_time %d \n",
@@ -278,10 +278,10 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                                      i_motion_control.set_motion_control_config(motion_ctrl_config);
 
                                      motion_ctrl_config = i_motion_control.get_motion_control_config();
-                                     printf("Kpp:%d Kpi:%d Kpd:%d kpl:%d\n",  motion_ctrl_config.position_kp,
+                                     printf("Kpp:%f Kpi:%f Kpd:%f kpl:%d\n",  motion_ctrl_config.position_kp,
                                              motion_ctrl_config.position_ki, motion_ctrl_config.position_kd,
                                              motion_ctrl_config.position_integral_limit);
-                                     printf("Kvp:%d Kvi:%d Kvd:%d kvl:%d\n",  motion_ctrl_config.velocity_kp,
+                                     printf("Kvp:%f Kvi:%f Kvd:%f kvl:%d\n",  motion_ctrl_config.velocity_kp,
                                              motion_ctrl_config.velocity_ki, motion_ctrl_config.velocity_kd,
                                              motion_ctrl_config.velocity_integral_limit);
 
@@ -313,7 +313,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                                      i_motion_control.set_motion_control_config(motion_ctrl_config);
 
                                      motion_ctrl_config = i_motion_control.get_motion_control_config();
-                                     printf("Kp:%d Ki:%d Kd:%d i_lim:%d\n",  motion_ctrl_config.position_kp,
+                                     printf("Kp:%f Ki:f Kd:f i_lim:%d\n",  motion_ctrl_config.position_kp,
                                              motion_ctrl_config.position_ki, motion_ctrl_config.position_kd,
                                              motion_ctrl_config.position_integral_limit);
 
@@ -383,7 +383,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
         //position commands
         case 'p':
                 downstream_control_data.offset_torque = 0;
-                downstream_control_data.position_cmd = value;
+                downstream_control_data.position_cmd = (int)value;
                 motion_ctrl_config = i_motion_control.get_motion_control_config();
                 switch(mode_2)
                 {
@@ -392,7 +392,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         //bug: the first time after one p# command p0 doesn't use the profile; only the way back to zero
                         motion_ctrl_config.enable_profiler = 1;
                         i_motion_control.set_motion_control_config(motion_ctrl_config);
-                        printf("Go to %d with profile\n", value);
+                        printf("Go to %d with profile\n", (int)value);
                         i_motion_control.update_control_data(downstream_control_data);
                         break;
                 //step command (forward and backward)
@@ -402,20 +402,20 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         //with profile
                         case 'p':
                                 motion_ctrl_config.enable_profiler = 1;
-                                printf("position cmd: %d to %d with profile\n", value, -value);
+                                printf("position cmd: %d to %d with profile\n", (int)value, (int)-value);
                                 break;
                         //without profile
                         default:
                                 motion_ctrl_config.enable_profiler = 0;
-                                printf("position cmd: %d to %d\n", value, -value);
+                                printf("position cmd: %d to %d\n", (int)value, (int)-value);
                                 break;
                         }
                         i_motion_control.set_motion_control_config(motion_ctrl_config);
                         downstream_control_data.offset_torque = 0;
-                        downstream_control_data.position_cmd = value;
+                        downstream_control_data.position_cmd = (int)value;
                         i_motion_control.update_control_data(downstream_control_data);
                         delay_ticks(1500*1000*tile_usec);
-                        downstream_control_data.position_cmd = -value;
+                        downstream_control_data.position_cmd = -(int)value;
                         i_motion_control.update_control_data(downstream_control_data);
                         delay_ticks(1500*1000*tile_usec);
                         downstream_control_data.position_cmd = 0;
@@ -425,7 +425,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                 default:
                         motion_ctrl_config.enable_profiler = 0;
                         i_motion_control.set_motion_control_config(motion_ctrl_config);
-                        printf("Go to %d\n", value);
+                        printf("Go to %d\n", (int)value);
                         i_motion_control.update_control_data(downstream_control_data);
                         break;
                 }
@@ -434,31 +434,31 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
         //velocity commands
         case 'v':
                 downstream_control_data.offset_torque = 0;
-                downstream_control_data.velocity_cmd = value;
+                downstream_control_data.velocity_cmd = (int)value;
                 motion_ctrl_config = i_motion_control.get_motion_control_config();
                 switch(mode_2)
                 {
                 //step command (forward and backward)
                 case 's':
                         downstream_control_data.offset_torque = 0;
-                        downstream_control_data.velocity_cmd = value;
+                        downstream_control_data.velocity_cmd = (int)value;
                         switch(mode_3)
                         {
                         //with profile
                         case 'p':
                                 motion_ctrl_config.enable_profiler = 1;
-                                printf("velocity cmd: %d to %d with profile\n", value, -value);
+                                printf("velocity cmd: %d to %d with profile\n", (int)value, (int)-value);
                                 break;
                         //without profile
                         default:
                                 motion_ctrl_config.enable_profiler = 0;
-                                printf("velocity cmd: %d to %d\n", value, -value);
+                                printf("velocity cmd: %d to %d\n", (int)value, (int)-value);
                                 break;
                         }
                         i_motion_control.set_motion_control_config(motion_ctrl_config);
                         i_motion_control.update_control_data(downstream_control_data);
                         delay_ticks(1000*1000*tile_usec);
-                        downstream_control_data.velocity_cmd = -value;
+                        downstream_control_data.velocity_cmd = (int)-value;
                         i_motion_control.update_control_data(downstream_control_data);
                         delay_ticks(1000*1000*tile_usec);
                         downstream_control_data.velocity_cmd = 0;
@@ -467,7 +467,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                 //direct command
                 default:
                         downstream_control_data.offset_torque = 0;
-                        downstream_control_data.velocity_cmd = value;
+                        downstream_control_data.velocity_cmd = (int)value;
                         i_motion_control.update_control_data(downstream_control_data);
                         printf("set velocity %d\n", downstream_control_data.velocity_cmd);
                         break;
@@ -477,13 +477,13 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
         //set torque commmand
         case 't':
                 downstream_control_data.offset_torque = 0;
-                downstream_control_data.torque_cmd = value;
+                downstream_control_data.torque_cmd = (int)value;
                 motion_ctrl_config = i_motion_control.get_motion_control_config();
                 switch(mode_2)
                 {
                 //step command (forward and backward)
                 case 's':
-                        downstream_control_data.torque_cmd = value;
+                        downstream_control_data.torque_cmd = (int)value;
                         switch(mode_3)
                         {
                         //torque safe mode
@@ -495,27 +495,27 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         //with profile
                         case 'p':
                                 motion_ctrl_config.enable_profiler = 1;
-                                printf("torque cmd: %d to %d with profile\n", value, -value);
+                                printf("torque cmd: %d to %d with profile\n", (int)value, (int)-value);
                                 break;
                         //without profile
                         default:
                                 motion_ctrl_config.enable_profiler = 0;
-                                printf("torque cmd: %d to %d\n", value, -value);
+                                printf("torque cmd: %d to %d\n", (int)value, (int)-value);
                                 break;
                         }
                         i_motion_control.set_motion_control_config(motion_ctrl_config);
                         i_motion_control.update_control_data(downstream_control_data);
                         delay_ticks(1000*1000*tile_usec);
-                        downstream_control_data.torque_cmd = -value;
+                        downstream_control_data.torque_cmd = (int)-value;
                         i_motion_control.update_control_data(downstream_control_data);
                         delay_ticks(1000*1000*tile_usec);
                         downstream_control_data.torque_cmd = 0;
                         i_motion_control.update_control_data(downstream_control_data);
                         break;
                 case 'p':
-                        downstream_control_data.torque_cmd = value;
+                        downstream_control_data.torque_cmd = (int)value;
                         motion_ctrl_config.enable_profiler = 1;
-                        printf("torque cmd: %d with profile\n", value);
+                        printf("torque cmd: %d with profile\n", (int)value);
                         i_motion_control.set_motion_control_config(motion_ctrl_config);
                         i_motion_control.update_control_data(downstream_control_data);
                         break;
@@ -525,7 +525,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         motion_ctrl_config.enable_profiler = 0;
                         i_motion_control.set_motion_control_config(motion_ctrl_config);
                         downstream_control_data.offset_torque = 0;
-                        downstream_control_data.torque_cmd = value;
+                        downstream_control_data.torque_cmd = (int)value;
                         i_motion_control.update_control_data(downstream_control_data);
                         printf("set torque %d\n", downstream_control_data.torque_cmd);
                         break;
@@ -596,10 +596,10 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                             }
                                 break;
                         case 'l':
-                                motion_ctrl_config.position_integral_limit = value;
+                                motion_ctrl_config.position_integral_limit = (int)value;
                                 break;
                         case 'j':
-                                motion_ctrl_config.moment_of_inertia = value;
+                                motion_ctrl_config.moment_of_inertia = (int)value;
                                 break;
                         default:
                                 break;
@@ -609,12 +609,12 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         motion_ctrl_config = i_motion_control.get_motion_control_config();
 
                         if (mode_4 == 0)
-                            printf("Kp:%.2f Ki:%.2f Kd:%.2f j%d i_lim:%d\n",
+                            printf("Kp:%f Ki:%f Kd:%f j%d i_lim:%d\n",
                                     motion_ctrl_config.position_kp, motion_ctrl_config.position_ki, motion_ctrl_config.position_kd,
                                     motion_ctrl_config.moment_of_inertia, motion_ctrl_config.position_integral_limit);
                         else
                         {
-                            printf("Kp_l:%.2f Ki_l:%.2f Kd_l:%.2f i_lim:%d\n",
+                            printf("Kp_l:%f Ki_l:%f Kd_l:%f i_lim:%d\n",
                                     motion_ctrl_config.position_kp_l, motion_ctrl_config.position_ki_l, motion_ctrl_config.position_kd_l, motion_ctrl_config.position_integral_limit);
                             printf("Kp_h:%.2f Ki_h:%.2f Kd_h:%.2f i_lim:%d\n",
                                 motion_ctrl_config.position_kp_h, motion_ctrl_config.position_ki_h, motion_ctrl_config.position_kd_h, motion_ctrl_config.position_integral_limit);
@@ -675,7 +675,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                             break;
 
                         case 'l':
-                                motion_ctrl_config.velocity_integral_limit = value;
+                                motion_ctrl_config.velocity_integral_limit = (int)value;
                                 break;
                         default:
                                 break;
@@ -685,14 +685,14 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         motion_ctrl_config = i_motion_control.get_motion_control_config();
 
                         if(mode_4 == 0)
-                            printf("Kp:%.2f Ki:%.2f Kd:%.2f i_lim:%d\n",
+                            printf("Kp:%f Ki:%f Kd:%f i_lim:%d\n",
                                 motion_ctrl_config.velocity_kp, motion_ctrl_config.velocity_ki, motion_ctrl_config.velocity_kd,
                                 motion_ctrl_config.velocity_integral_limit);
                         else
                         {
-                            printf("Kp_l:%.2f Ki_l:%.2f Kd_l:%.2f i_lim:%d\n",
+                            printf("Kp_l:%f Ki_l:%f Kd_l:%f i_lim:%d\n",
                                     motion_ctrl_config.velocity_kp_l, motion_ctrl_config.velocity_ki_l, motion_ctrl_config.velocity_kd_l, motion_ctrl_config.velocity_integral_limit);
-                        printf("Kp_h:%.2f Ki_h:%.2f Kd_h:%.2f i_lim:%d\n",
+                        printf("Kp_h:%f Ki_h:%f Kd_h:%f i_lim:%d\n",
                                 motion_ctrl_config.velocity_kp_h, motion_ctrl_config.velocity_ki_h, motion_ctrl_config.velocity_kd_h, motion_ctrl_config.velocity_integral_limit);
                         }
 
@@ -702,7 +702,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         switch(mode_3)
                         {
                         case 'f':
-                            motion_ctrl_config.filter = value;
+                            motion_ctrl_config.filter = (int)value;
                                 break;
                         default:
                             i_motion_control.set_motion_control_config(motion_ctrl_config);
@@ -731,28 +731,28 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                     switch(mode_3)
                     {
                     case 'u':
-                        motion_ctrl_config.max_pos_range_limit = value;
+                        motion_ctrl_config.max_pos_range_limit = (int)value;
                         break;
                     case 'l':
-                        motion_ctrl_config.min_pos_range_limit = value;
+                        motion_ctrl_config.min_pos_range_limit = (int)value;
                         break;
                     default:
-                        motion_ctrl_config.max_pos_range_limit = value;
-                        motion_ctrl_config.min_pos_range_limit = -value;
+                        motion_ctrl_config.max_pos_range_limit = (int)value;
+                        motion_ctrl_config.min_pos_range_limit = (int)-value;
                         break;
                     }
                     break;
 
                 //max velocity limit
                 case 'v':
-                        motion_ctrl_config.max_motor_speed = value;
+                        motion_ctrl_config.max_motor_speed = (int)value;
                         break;
 
                 //max torque limit
                 case 't':
-                        motion_ctrl_config.max_torque = value;
+                        motion_ctrl_config.max_torque = (int)value;
                         motorcontrol_config = i_motion_control.get_motorcontrol_config();
-                        motorcontrol_config.max_torque = value;
+                        motorcontrol_config.max_torque = (int)value;
                         i_motion_control.set_motorcontrol_config(motorcontrol_config);
                         brake_flag = 0;
                         break;
@@ -824,7 +824,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                 switch(mode_2)
                 {
                 case 'c':
-                        if (value == 1)
+                        if ((int)value == 1)
                         {
 
                             i_motion_control.enable_cogging_compensation(1);
@@ -838,22 +838,22 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         break;
 
                 case 'p':
-                        if (value == 1)
+                        if ((int)value == 1)
                         {
                             i_motion_control.enable_position_ctrl(POS_PID_CONTROLLER);
                             printf("simple PID pos ctrl enabled\n");
                         }
-                        else if (value == 2)
+                        else if ((int)value == 2)
                         {
                             i_motion_control.enable_position_ctrl(POS_PID_VELOCITY_CASCADED_CONTROLLER);
                             printf("vel.-cascaded pos ctrl enabled\n");
                         }
-                        else if (value == 3)
+                        else if ((int)value == 3)
                         {
                             i_motion_control.enable_position_ctrl(LT_POSITION_CONTROLLER);
                             printf("limited torque pos ctrl enabled\n");
                         }
-                        else if (value == 4)
+                        else if ((int)value == 4)
                         {
                             i_motion_control.enable_position_ctrl(POS_PID_GAIN_SCHEDULING_CONTROLLER);
                             printf("gain scheduling pos ctrl enabled\n");
@@ -866,7 +866,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         }
                         break;
                 case 'v':
-                        if (value == 1)
+                        if ((int)value == 1)
                         {
                             i_motion_control.enable_velocity_ctrl();
                             printf("velocity ctrl enabled\n");
@@ -879,7 +879,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         }
                         break;
                 case 't':
-                        if (value == 1)
+                        if ((int)value == 1)
                         {
                             i_motion_control.enable_torque_ctrl();
                             printf("torque ctrl enabled\n");
@@ -916,16 +916,16 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                 switch(mode_2)
                 {
                 case 'a':
-                        motion_ctrl_config.max_acceleration_profiler = value;
+                        motion_ctrl_config.max_acceleration_profiler = (int)value;
                         break;
                 case 'd':
-                        motion_ctrl_config.max_deceleration_profiler = value;
+                        motion_ctrl_config.max_deceleration_profiler = (int)value;
                         break;
                 case 'v':
-                        motion_ctrl_config.max_speed_profiler = value;
+                        motion_ctrl_config.max_speed_profiler = (int)value;
                         break;
                 case 't':
-                        motion_ctrl_config.max_torque_rate_profiler = value;
+                        motion_ctrl_config.max_torque_rate_profiler = (int)value;
                         break;
 
                 default:
@@ -942,7 +942,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                 {
                 case 's':
                         motion_ctrl_config = i_motion_control.get_motion_control_config();
-                        motion_ctrl_config.brake_release_strategy = value;
+                        motion_ctrl_config.brake_release_strategy = (int)value;
                         i_motion_control.set_motion_control_config(motion_ctrl_config);
                         printf("set brake release strategy to %d\n", motion_ctrl_config.brake_release_strategy);
                         break;
@@ -954,7 +954,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                         {
                         case 'n':// nominal voltage of dc-bus
                                 // set
-                                motion_ctrl_config.dc_bus_voltage=value;
+                                motion_ctrl_config.dc_bus_voltage=(int)value;
                                 i_motion_control.set_motion_control_config(motion_ctrl_config);
                                 // check
                                 motion_ctrl_config = i_motion_control.get_motion_control_config();
@@ -964,7 +964,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
 
                         case 'p':// pull voltage for releasing the brake at startup
                                 //set
-                                motion_ctrl_config.pull_brake_voltage=value;
+                                motion_ctrl_config.pull_brake_voltage=(int)value;
 
                                 i_motion_control.set_motion_control_config(motion_ctrl_config);
                                 // check
@@ -975,7 +975,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
 
                         case 'h':// hold voltage for holding the brake after it is pulled
                                 //set
-                                motion_ctrl_config.hold_brake_voltage=value;
+                                motion_ctrl_config.hold_brake_voltage=(int)value;
 
                                 i_motion_control.set_motion_control_config(motion_ctrl_config);
                                 // check
@@ -991,7 +991,7 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                 case 't'://set pull time
                         motion_ctrl_config = i_motion_control.get_motion_control_config();
                         //set
-                        motion_ctrl_config.pull_brake_time=value;
+                        motion_ctrl_config.pull_brake_time=(int)value;
 
                         if(motion_ctrl_config.pull_brake_time<0)    motion_ctrl_config.pull_brake_time=0;
 
@@ -1025,14 +1025,14 @@ void control_tuning_console(client interface MotionControlInterface i_motion_con
                 {
                 //set offset
                 case 's':
-                    motorcontrol_config.commutation_angle_offset = value;
+                    motorcontrol_config.commutation_angle_offset = (int)value;
                     i_motion_control.set_motorcontrol_config(motorcontrol_config);
                     printf("set offset to %d\n", motorcontrol_config.commutation_angle_offset);
                     brake_flag = 0;
                     break;
                 //set percent offset torque
                 case 'p':
-                    motorcontrol_config.percent_offset_torque = value;
+                    motorcontrol_config.percent_offset_torque = (int)value;
                     i_motion_control.set_motorcontrol_config(motorcontrol_config);
                     printf("set offset detection torque percentage to %d\n", motorcontrol_config.percent_offset_torque);
                     brake_flag = 0;

--- a/module_controllers/include/controllers.h
+++ b/module_controllers/include/controllers.h
@@ -53,7 +53,7 @@ void pid_init(PIDT1param &param);
  *
  * @return void
  */
-void pid_set_parameters(double Kp, double Ki, double Kd, double integral_limit, int T_s, PIDT1param &param);
+void pid_set_parameters(double Kp, double Ki, double Kd, double integral_limit, double T_s, PIDT1param &param);
 
 /**
  * @brief updating the PIDT1 controller.

--- a/module_controllers/include/controllers.h
+++ b/module_controllers/include/controllers.h
@@ -26,7 +26,7 @@ typedef struct {
     double derivative_1n;
     double actual_value_1n;
     double error_value_1n;
-    double T_s;                // sampling-Time in seconds
+    double T_s;                // sampling time in seconds
     int v;                  // first order element in D part with time constant T_v
                             // T_v = Td / v => v €[4, 20]
     derivative_feedback b;  // derivative feedback, error = b*ref-y

--- a/module_controllers/include/controllers.h
+++ b/module_controllers/include/controllers.h
@@ -26,7 +26,7 @@ typedef struct {
     double derivative_1n;
     double actual_value_1n;
     double error_value_1n;
-    int T_s;                // sampling-Time in microseconds
+    double T_s;                // sampling-Time in seconds
     int v;                  // first order element in D part with time constant T_v
                             // T_v = Td / v => v €[4, 20]
     derivative_feedback b;  // derivative feedback, error = b*ref-y
@@ -65,7 +65,7 @@ void pid_set_parameters(double Kp, double Ki, double Kd, double integral_limit, 
  *
  * @return the output of pid controller
  */
-double pid_update(double desired_value, double actual_value, int T_s, PIDT1param &param);
+double pid_update(double desired_value, double actual_value, double T_s, PIDT1param &param);
 
 /**
  * @brief resetting the parameters of the PIDT1 controller.

--- a/module_controllers/src/controllers.xc
+++ b/module_controllers/src/controllers.xc
@@ -39,12 +39,12 @@ void pid_init(PIDT1param &param)
  * @param input, I parameter scaled by 1e10
  * @param input, D parameter scaled by 1e6
  * @param input, Integral limit
- * @param input, sampling time in us (microseconds)
+ * @param input, sampling time in seconds
  * @param structure including the parameters of the PIDT1 controller
  *
  * @return void
  */
-void pid_set_parameters(double Kp, double Ki, double Kd, double integral_limit, int T_s, PIDT1param &param)
+void pid_set_parameters(double Kp, double Ki, double Kd, double integral_limit, double T_s, PIDT1param &param)
 {
     param.Kp = Kp;
     param.Ki = Ki;
@@ -62,7 +62,7 @@ void pid_set_parameters(double Kp, double Ki, double Kd, double integral_limit, 
     if (param.Kd == 0)
         param.derivative = 0; // reset the derivative in case kd is set to 0
     else
-        param.v = 13;    // it is recommended to be in range [4, 20]
+        param.v = 100;
 
     param.T_s = T_s;
     param.b = PSEUDO_DERIVATIVE;

--- a/module_controllers/src/controllers.xc
+++ b/module_controllers/src/controllers.xc
@@ -36,7 +36,7 @@ void pid_init(PIDT1param &param)
 /**
  * @brief setting the parameters of the PIDT1 controller.
  * @param input, P parameter scaled by 1e6
- * @param input, I parameter scaled by 1e8
+ * @param input, I parameter scaled by 1e10
  * @param input, D parameter scaled by 1e6
  * @param input, Integral limit
  * @param input, sampling time in us (microseconds)
@@ -46,9 +46,9 @@ void pid_init(PIDT1param &param)
  */
 void pid_set_parameters(double Kp, double Ki, double Kd, double integral_limit, int T_s, PIDT1param &param)
 {
-    param.Kp = Kp/1000000.00;
-    param.Ki = Ki/100000000.00;
-    param.Kd = Kd/1000000.00;
+    param.Kp = Kp;
+    param.Ki = Ki;
+    param.Kd = Kd;
     param.integral_limit = integral_limit;
 
     if(param.Ki == 0)
@@ -77,7 +77,7 @@ void pid_set_parameters(double Kp, double Ki, double Kd, double integral_limit, 
  *
  * @return the output of PIDT1 controller
  */
-double pid_update(double desired_value, double actual_value, int T_s, PIDT1param &param)
+double pid_update(double desired_value, double actual_value, double T_s, PIDT1param &param)
 {
     double error=0.00, cmd=0.00, derivat_input = 0.00;
 

--- a/module_motion_control/include/motion_control_service.h
+++ b/module_motion_control/include/motion_control_service.h
@@ -105,9 +105,9 @@ typedef struct {
     int max_speed_profiler;             /**< Parameter for setting the maximum speed in profiler mode */
     int max_torque_rate_profiler;       /**< Parameter for setting the maximum torque in profiler mode */
 
-    int position_kp;                    /**< Parameter for position controller P-constant */
-    int position_ki;                    /**< Parameter for position controller I-constant */
-    int position_kd;                    /**< Parameter for position controller D-constant */
+    float position_kp;                    /**< Parameter for position controller P-constant */
+    float position_ki;                    /**< Parameter for position controller I-constant */
+    float position_kd;                    /**< Parameter for position controller D-constant */
     int position_integral_limit;        /**< Parameter for integral limit of position pid controller */
 
     int position_control_autotune;      /**< Parameter for enabling/disabling automatic tuning of position controller*/
@@ -116,9 +116,9 @@ typedef struct {
     int per_thousand_overshoot_autotune;      /**< Overshoot limit while tuning (it is set as per thousand of step amplitude)*/
     int rise_time_freedom_percent_autotune;   /**< This value helps the tuner to find out whether the ki is high enough or not. By default set this value to 300, and if the tuner is not able to find proper values (and the response is having oscillations), increase this value to 400 or 500.*/
 
-    int velocity_kp;                    /**< Parameter for velocity controller P-constant */
-    int velocity_ki;                    /**< Parameter for velocity controller I-constant */
-    int velocity_kd;                    /**< Parameter for velocity controller D-constant */
+    float velocity_kp;                    /**< Parameter for velocity controller P-constant */
+    float velocity_ki;                    /**< Parameter for velocity controller I-constant */
+    float velocity_kd;                    /**< Parameter for velocity controller D-constant */
     int velocity_integral_limit;        /**< Parameter for integral limit of velocity pid controller */
 
     int enable_velocity_auto_tuner;     /**< Parameter for enabling/disabling auto tuner for velocity controller */

--- a/module_motion_control/include/motion_control_service.h
+++ b/module_motion_control/include/motion_control_service.h
@@ -145,18 +145,18 @@ typedef struct {
 
     int filter;
 
-    int position_kp_l;
-    int position_ki_l;
-    int position_kd_l;
-    int position_kp_h;
-    int position_ki_h;
-    int position_kd_h;
-    int velocity_kp_l;
-    int velocity_ki_l;
-    int velocity_kd_l;
-    int velocity_kp_h;
-    int velocity_ki_h;
-    int velocity_kd_h;
+    float position_kp_l;
+    float position_ki_l;
+    float position_kd_l;
+    float position_kp_h;
+    float position_ki_h;
+    float position_kd_h;
+    float velocity_kp_l;
+    float velocity_ki_l;
+    float velocity_kd_l;
+    float velocity_kp_h;
+    float velocity_ki_h;
+    float velocity_kd_h;
     int velocity_lo_l;
     int velocity_hi_l;
 } MotionControlConfig;

--- a/module_motion_control/include/motion_control_service.h
+++ b/module_motion_control/include/motion_control_service.h
@@ -25,6 +25,11 @@
 #define POSITION_CONTROL_LOOP_PERIOD    333
 
 /**
+ * @brief Period for the control loop [microseconds].
+ */
+#define POSITION_CONTROL_LOOP_PERIOD_SEC  POSITION_CONTROL_LOOP_PERIOD * 1e-6
+
+/**
  * @brief Threshold to detect brake release in ticks.
  */
 #define BRAKE_RELEASE_THRESHOLD         4000

--- a/module_motion_control/src/motion_control_service.xc
+++ b/module_motion_control/src/motion_control_service.xc
@@ -690,7 +690,7 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                         }
 
                         velocity_controller_auto_tune(velocity_auto_tune, motion_ctrl_config, velocity_ref_in_k, velocity_k, POSITION_CONTROL_LOOP_PERIOD);
-                        torque_ref_k = pid_update(velocity_ref_in_k, velocity_k, POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
+                        torque_ref_k = pid_update(velocity_ref_in_k, velocity_k, POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
                         if(velocity_auto_tune.enable == 0)
                         {
                             torque_ref_k=0;
@@ -706,12 +706,12 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                     {
                         velocity_ref_in_k = velocity_profiler(velocity_ref_k, velocity_ref_in_k_1n, velocity_k, profiler_param, POSITION_CONTROL_LOOP_PERIOD);
                         velocity_ref_in_k_1n = velocity_ref_in_k;
-                        torque_ref_k = pid_update(velocity_ref_in_k, velocity_k, POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
+                        torque_ref_k = pid_update(velocity_ref_in_k, velocity_k, POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
                     }
                     else if(motion_ctrl_config.enable_profiler==0)
                     {
                         velocity_ref_in_k = velocity_ref_k;
-                        torque_ref_k = pid_update(velocity_ref_in_k, velocity_k, POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
+                        torque_ref_k = pid_update(velocity_ref_in_k, velocity_k, POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
                     }
                     //Recording function for the cogging torque
                     if (motion_ctrl_config.enable_compensation_recording)
@@ -850,7 +850,7 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
 
                     if (pos_control_mode == POS_PID_CONTROLLER)
                     {
-                        torque_ref_k = pid_update(position_ref_in_k, position_k, POSITION_CONTROL_LOOP_PERIOD, position_control_pid_param);
+                        torque_ref_k = pid_update(position_ref_in_k, position_k, POSITION_CONTROL_LOOP_PERIOD_SEC, position_control_pid_param);
                     }
                     else if (pos_control_mode == POS_PID_GAIN_SCHEDULING_CONTROLLER)
                     {
@@ -862,11 +862,11 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                         pid_set_parameters((double)motion_ctrl_config.velocity_kp, (double)motion_ctrl_config.velocity_ki, (double)motion_ctrl_config.velocity_kd, (double)motion_ctrl_config.velocity_integral_limit, POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
                         pid_set_parameters((double)motion_ctrl_config.position_kp, (double)motion_ctrl_config.position_ki, (double)motion_ctrl_config.position_kd, (double)motion_ctrl_config.position_integral_limit, POSITION_CONTROL_LOOP_PERIOD, position_control_pid_param);
 
-                        velocity_ref_k = pid_update(position_ref_in_k, position_k, POSITION_CONTROL_LOOP_PERIOD, position_control_pid_param);
+                        velocity_ref_k = pid_update(position_ref_in_k, position_k, POSITION_CONTROL_LOOP_PERIOD_SEC, position_control_pid_param);
                         if(velocity_ref_k > motion_ctrl_config.max_motor_speed) velocity_ref_k = motion_ctrl_config.max_motor_speed;
                         if(velocity_ref_k < -motion_ctrl_config.max_motor_speed) velocity_ref_k = -motion_ctrl_config.max_motor_speed;
 
-                        torque_ref_k = pid_update(velocity_ref_k, velocity_k, POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
+                        torque_ref_k = pid_update(velocity_ref_k, velocity_k, POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
                     }
                     else if (pos_control_mode == POS_PID_VELOCITY_CASCADED_CONTROLLER)
                     {
@@ -897,17 +897,17 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                             position_ref_in_k_2n = position_ref_in_k_1n;
                             position_ref_in_k_1n = position_ref_in_k;
 
-                            velocity_ref_k =pid_update(position_ref_in_k, position_k, POSITION_CONTROL_LOOP_PERIOD, position_control_pid_param);
+                            velocity_ref_k =pid_update(position_ref_in_k, position_k, POSITION_CONTROL_LOOP_PERIOD_SEC, position_control_pid_param);
                             if(velocity_ref_k> motion_ctrl_config.max_motor_speed) velocity_ref_k = motion_ctrl_config.max_motor_speed;
                             if(velocity_ref_k<-motion_ctrl_config.max_motor_speed) velocity_ref_k =-motion_ctrl_config.max_motor_speed;
-                            torque_ref_k   =pid_update(velocity_ref_k   , velocity_k, POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
+                            torque_ref_k   =pid_update(velocity_ref_k   , velocity_k, POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
                         }
                         else
                         {
-                            velocity_ref_k =pid_update(position_ref_in_k, position_k, POSITION_CONTROL_LOOP_PERIOD, position_control_pid_param);
+                            velocity_ref_k =pid_update(position_ref_in_k, position_k, POSITION_CONTROL_LOOP_PERIOD_SEC, position_control_pid_param);
                             if(velocity_ref_k> motion_ctrl_config.max_motor_speed) velocity_ref_k = motion_ctrl_config.max_motor_speed;
                             if(velocity_ref_k<-motion_ctrl_config.max_motor_speed) velocity_ref_k =-motion_ctrl_config.max_motor_speed;
-                            torque_ref_k   =pid_update(velocity_ref_k   , velocity_k, POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
+                            torque_ref_k   =pid_update(velocity_ref_k   , velocity_k, POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
                         }
                     }
                     else if (pos_control_mode == LT_POSITION_CONTROLLER)

--- a/module_motion_control/src/motion_control_service.xc
+++ b/module_motion_control/src/motion_control_service.xc
@@ -504,11 +504,11 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
 
     pid_init(velocity_control_pid_param);
     if(motion_ctrl_config.velocity_kp<0)            motion_ctrl_config.velocity_kp=0;
-    if(motion_ctrl_config.velocity_kp>100000000)    motion_ctrl_config.velocity_kp=100000000;
+    if(motion_ctrl_config.velocity_kp>100)    motion_ctrl_config.velocity_kp=100;
     if(motion_ctrl_config.velocity_ki<0)            motion_ctrl_config.velocity_ki=0;
-    if(motion_ctrl_config.velocity_ki>100000000)    motion_ctrl_config.velocity_ki=100000000;
+    if(motion_ctrl_config.velocity_ki>100)    motion_ctrl_config.velocity_ki=100;
     if(motion_ctrl_config.velocity_kd<0)            motion_ctrl_config.velocity_kd=0;
-    if(motion_ctrl_config.velocity_kd>100000000)    motion_ctrl_config.velocity_kd=100000000;
+    if(motion_ctrl_config.velocity_kd>100)    motion_ctrl_config.velocity_kd=100;
     pid_set_parameters(
             (double)motion_ctrl_config.velocity_kp, (double)motion_ctrl_config.velocity_ki,
             (double)motion_ctrl_config.velocity_kd, (double)motion_ctrl_config.velocity_integral_limit,
@@ -516,42 +516,42 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
 
     pid_init(position_control_pid_param);
     if(motion_ctrl_config.position_kp<0)            motion_ctrl_config.position_kp=0;
-    if(motion_ctrl_config.position_kp>100000000)    motion_ctrl_config.position_kp=100000000;
+    if(motion_ctrl_config.position_kp>100)    motion_ctrl_config.position_kp = 100;
     if(motion_ctrl_config.position_ki<0)            motion_ctrl_config.position_ki=0;
-    if(motion_ctrl_config.position_ki>100000000)    motion_ctrl_config.position_ki=100000000;
+    if(motion_ctrl_config.position_ki>100)    motion_ctrl_config.position_ki = 100;
     if(motion_ctrl_config.position_kd<0)            motion_ctrl_config.position_kd=0;
-    if(motion_ctrl_config.position_kd>100000000)    motion_ctrl_config.position_kd=100000000;
+    if(motion_ctrl_config.position_kd>100)    motion_ctrl_config.position_kd = 100;
     pid_set_parameters((double)motion_ctrl_config.position_kp, (double)motion_ctrl_config.position_ki,
             (double)motion_ctrl_config.position_kd, (double)motion_ctrl_config.position_integral_limit,
-            POSITION_CONTROL_LOOP_PERIOD, position_control_pid_param);
+            POSITION_CONTROL_LOOP_PERIOD_SEC, position_control_pid_param);
 
     // initialize GS controller params to zero
     gain_scheduling_init(gain_sch_param);
     // set GS controller params to default ones from configuration file
     if(motion_ctrl_config.position_kp_l<0)            motion_ctrl_config.position_kp_l=0;
-    if(motion_ctrl_config.position_kp_l>100000000)    motion_ctrl_config.position_kp_l=100000000;
+    if(motion_ctrl_config.position_kp_l>100)    motion_ctrl_config.position_kp_l=100;
     if(motion_ctrl_config.position_ki_l<0)            motion_ctrl_config.position_ki_l=0;
-    if(motion_ctrl_config.position_ki_l>100000000)    motion_ctrl_config.position_ki_l=100000000;
+    if(motion_ctrl_config.position_ki_l>100)    motion_ctrl_config.position_ki_l=100;
     if(motion_ctrl_config.position_kd_l<0)            motion_ctrl_config.position_kd_l=0;
-    if(motion_ctrl_config.position_kd_l>100000000)    motion_ctrl_config.position_kd_l=100000000;
+    if(motion_ctrl_config.position_kd_l>100)    motion_ctrl_config.position_kd_l=100;
     if(motion_ctrl_config.position_kp_h<0)            motion_ctrl_config.position_kp_h=0;
-    if(motion_ctrl_config.position_kp_h>100000000)    motion_ctrl_config.position_kp_h=100000000;
+    if(motion_ctrl_config.position_kp_h>100)    motion_ctrl_config.position_kp_h=100;
     if(motion_ctrl_config.position_ki_h<0)            motion_ctrl_config.position_ki_h=0;
-    if(motion_ctrl_config.position_ki_h>100000000)    motion_ctrl_config.position_ki_h=100000000;
+    if(motion_ctrl_config.position_ki_h>100)    motion_ctrl_config.position_ki_h=100;
     if(motion_ctrl_config.position_kd_h<0)            motion_ctrl_config.position_kd_h=0;
-    if(motion_ctrl_config.position_kd_h>100000000)    motion_ctrl_config.position_kd_h=100000000;
+    if(motion_ctrl_config.position_kd_h>100)    motion_ctrl_config.position_kd_h=100;
     if(motion_ctrl_config.velocity_kp_l<0)            motion_ctrl_config.velocity_kp_l=0;
-    if(motion_ctrl_config.velocity_kp_l>100000000)    motion_ctrl_config.velocity_kp_l=100000000;
+    if(motion_ctrl_config.velocity_kp_l>100)    motion_ctrl_config.velocity_kp_l=100;
     if(motion_ctrl_config.velocity_ki_l<0)            motion_ctrl_config.velocity_ki_l=0;
-    if(motion_ctrl_config.velocity_ki_l>100000000)    motion_ctrl_config.velocity_ki_l=100000000;
+    if(motion_ctrl_config.velocity_ki_l>100)    motion_ctrl_config.velocity_ki_l=100;
     if(motion_ctrl_config.velocity_kd_l<0)            motion_ctrl_config.velocity_kd_l=0;
-    if(motion_ctrl_config.velocity_kd_l>100000000)    motion_ctrl_config.velocity_kd_l=100000000;
+    if(motion_ctrl_config.velocity_kd_l>100)    motion_ctrl_config.velocity_kd_l=100;
     if(motion_ctrl_config.velocity_kp_h<0)            motion_ctrl_config.velocity_kp_h=0;
-    if(motion_ctrl_config.velocity_kp_h>100000000)    motion_ctrl_config.velocity_kp_h=100000000;
+    if(motion_ctrl_config.velocity_kp_h>100)    motion_ctrl_config.velocity_kp_h=100;
     if(motion_ctrl_config.velocity_ki_h<0)            motion_ctrl_config.velocity_ki_h=0;
-    if(motion_ctrl_config.velocity_ki_h>100000000)    motion_ctrl_config.velocity_ki_h=100000000;
+    if(motion_ctrl_config.velocity_ki_h>100)    motion_ctrl_config.velocity_ki_h=100;
     if(motion_ctrl_config.velocity_kd_h<0)            motion_ctrl_config.velocity_kd_h=0;
-    if(motion_ctrl_config.velocity_kd_h>100000000)    motion_ctrl_config.velocity_kd_h=100000000;
+    if(motion_ctrl_config.velocity_kd_h>100)    motion_ctrl_config.velocity_kd_h=100;
     if(motion_ctrl_config.velocity_lo_l<0)            motion_ctrl_config.velocity_lo_l=0;
     if(motion_ctrl_config.velocity_lo_l>motion_ctrl_config.max_motor_speed)  motion_ctrl_config.velocity_lo_l=motion_ctrl_config.max_motor_speed;
     if(motion_ctrl_config.velocity_hi_l<0)            motion_ctrl_config.velocity_hi_l=0;
@@ -684,7 +684,7 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                             motion_ctrl_config.velocity_ki = 0;
                             motion_ctrl_config.velocity_kd = 0;
                             pid_init(velocity_control_pid_param);
-                            pid_set_parameters((double)motion_ctrl_config.velocity_kp, (double)motion_ctrl_config.velocity_ki, (double)motion_ctrl_config.velocity_kd, (double)motion_ctrl_config.velocity_integral_limit, POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
+                            pid_set_parameters((double)motion_ctrl_config.velocity_kp, (double)motion_ctrl_config.velocity_ki, (double)motion_ctrl_config.velocity_kd, (double)motion_ctrl_config.velocity_integral_limit, POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
 
                             velocity_auto_tune.enable = 1;
                         }
@@ -859,8 +859,8 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                         gain_scheduling_update(velocity_k, gain_sch_param, motion_ctrl_config);
 
                         // set params of PID controllers
-                        pid_set_parameters((double)motion_ctrl_config.velocity_kp, (double)motion_ctrl_config.velocity_ki, (double)motion_ctrl_config.velocity_kd, (double)motion_ctrl_config.velocity_integral_limit, POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
-                        pid_set_parameters((double)motion_ctrl_config.position_kp, (double)motion_ctrl_config.position_ki, (double)motion_ctrl_config.position_kd, (double)motion_ctrl_config.position_integral_limit, POSITION_CONTROL_LOOP_PERIOD, position_control_pid_param);
+                        pid_set_parameters((double)motion_ctrl_config.velocity_kp, (double)motion_ctrl_config.velocity_ki, (double)motion_ctrl_config.velocity_kd, (double)motion_ctrl_config.velocity_integral_limit, POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
+                        pid_set_parameters((double)motion_ctrl_config.position_kp, (double)motion_ctrl_config.position_ki, (double)motion_ctrl_config.position_kd, (double)motion_ctrl_config.position_integral_limit, POSITION_CONTROL_LOOP_PERIOD_SEC, position_control_pid_param);
 
                         velocity_ref_k = pid_update(position_ref_in_k, position_k, POSITION_CONTROL_LOOP_PERIOD_SEC, position_control_pid_param);
                         if(velocity_ref_k > motion_ctrl_config.max_motor_speed) velocity_ref_k = motion_ctrl_config.max_motor_speed;
@@ -888,8 +888,8 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                                 pid_init(velocity_control_pid_param);
                                 pid_init(position_control_pid_param);
 
-                                pid_set_parameters((double)motion_ctrl_config.velocity_kp, (double)motion_ctrl_config.velocity_ki, (double)motion_ctrl_config.velocity_kd, (double)motion_ctrl_config.velocity_integral_limit, POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
-                                pid_set_parameters((double)motion_ctrl_config.position_kp, (double)motion_ctrl_config.position_ki, (double)motion_ctrl_config.position_kd, (double)motion_ctrl_config.position_integral_limit, POSITION_CONTROL_LOOP_PERIOD, position_control_pid_param);
+                                pid_set_parameters((double)motion_ctrl_config.velocity_kp, (double)motion_ctrl_config.velocity_ki, (double)motion_ctrl_config.velocity_kd, (double)motion_ctrl_config.velocity_integral_limit, POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
+                                pid_set_parameters((double)motion_ctrl_config.position_kp, (double)motion_ctrl_config.position_ki, (double)motion_ctrl_config.position_kd, (double)motion_ctrl_config.position_integral_limit, POSITION_CONTROL_LOOP_PERIOD_SEC, position_control_pid_param);
                             }
 
 
@@ -1375,15 +1375,15 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
 
                 pid_init(velocity_control_pid_param);
                 if(motion_ctrl_config.velocity_kp<0)            motion_ctrl_config.velocity_kp=0;
-                if(motion_ctrl_config.velocity_kp>100000000)    motion_ctrl_config.velocity_kp=100000000;
+                if(motion_ctrl_config.velocity_kp>100)    motion_ctrl_config.velocity_kp=100;
                 if(motion_ctrl_config.velocity_ki<0)            motion_ctrl_config.velocity_ki=0;
-                if(motion_ctrl_config.velocity_ki>100000000)    motion_ctrl_config.velocity_ki=100000000;
+                if(motion_ctrl_config.velocity_ki>100)    motion_ctrl_config.velocity_ki=100;
                 if(motion_ctrl_config.velocity_kd<0)            motion_ctrl_config.velocity_kd=0;
-                if(motion_ctrl_config.velocity_kd>100000000)    motion_ctrl_config.velocity_kd=100000000;
+                if(motion_ctrl_config.velocity_kd>100)    motion_ctrl_config.velocity_kd=100;
                 pid_set_parameters(
                         (double)motion_ctrl_config.velocity_kp, (double)motion_ctrl_config.velocity_ki,
                         (double)motion_ctrl_config.velocity_kd, (double)motion_ctrl_config.velocity_integral_limit,
-                        POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
+                        POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
 
                 enable_motorcontrol(motion_ctrl_config, i_torque_control, upstream_control_data.position, special_brake_release_counter, special_brake_release_initial_position, special_brake_release_torque, motion_control_error);
 
@@ -1445,52 +1445,52 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                 motion_ctrl_config = in_config;
 
                 if(motion_ctrl_config.velocity_kp<0)            motion_ctrl_config.velocity_kp=0;
-                if(motion_ctrl_config.velocity_kp>100000000)    motion_ctrl_config.velocity_kp=100000000;
+                if(motion_ctrl_config.velocity_kp>100)    motion_ctrl_config.velocity_kp=100;
                 if(motion_ctrl_config.velocity_ki<0)            motion_ctrl_config.velocity_ki=0;
-                if(motion_ctrl_config.velocity_ki>100000000)    motion_ctrl_config.velocity_ki=100000000;
+                if(motion_ctrl_config.velocity_ki>100)    motion_ctrl_config.velocity_ki=100;
                 if(motion_ctrl_config.velocity_kd<0)            motion_ctrl_config.velocity_kd=0;
-                if(motion_ctrl_config.velocity_kd>100000000)    motion_ctrl_config.velocity_kd=100000000;
+                if(motion_ctrl_config.velocity_kd>100)    motion_ctrl_config.velocity_kd=100;
                 pid_set_parameters(
                         (double)motion_ctrl_config.velocity_kp, (double)motion_ctrl_config.velocity_ki,
                         (double)motion_ctrl_config.velocity_kd, (double)motion_ctrl_config.velocity_integral_limit,
-                        POSITION_CONTROL_LOOP_PERIOD, velocity_control_pid_param);
+                        POSITION_CONTROL_LOOP_PERIOD_SEC, velocity_control_pid_param);
 
 
                 if(motion_ctrl_config.position_kp<0)            motion_ctrl_config.position_kp=0;
-                if(motion_ctrl_config.position_kp>100000000)    motion_ctrl_config.position_kp=100000000;
+                if(motion_ctrl_config.position_kp>100)    motion_ctrl_config.position_kp=100;
                 if(motion_ctrl_config.position_ki<0)            motion_ctrl_config.position_ki=0;
-                if(motion_ctrl_config.position_ki>100000000)    motion_ctrl_config.position_ki=100000000;
+                if(motion_ctrl_config.position_ki>100)    motion_ctrl_config.position_ki=100;
                 if(motion_ctrl_config.position_kd<0)            motion_ctrl_config.position_kd=0;
-                if(motion_ctrl_config.position_kd>100000000)    motion_ctrl_config.position_kd=100000000;
+                if(motion_ctrl_config.position_kd>100)    motion_ctrl_config.position_kd=100;
                 pid_set_parameters((double)motion_ctrl_config.position_kp, (double)motion_ctrl_config.position_ki,
                         (double)motion_ctrl_config.position_kd, (double)motion_ctrl_config.position_integral_limit,
-                        POSITION_CONTROL_LOOP_PERIOD, position_control_pid_param);
+                        POSITION_CONTROL_LOOP_PERIOD_SEC, position_control_pid_param);
 
                 // set GS controller params
                 if(motion_ctrl_config.position_kp_l<0)            motion_ctrl_config.position_kp_l=0;
-                if(motion_ctrl_config.position_kp_l>100000000)    motion_ctrl_config.position_kp_l=100000000;
+                if(motion_ctrl_config.position_kp_l>100)    motion_ctrl_config.position_kp_l=100;
                 if(motion_ctrl_config.position_ki_l<0)            motion_ctrl_config.position_ki_l=0;
-                if(motion_ctrl_config.position_ki_l>100000000)    motion_ctrl_config.position_ki_l=100000000;
+                if(motion_ctrl_config.position_ki_l>100)    motion_ctrl_config.position_ki_l=100;
                 if(motion_ctrl_config.position_kd_l<0)            motion_ctrl_config.position_kd_l=0;
-                if(motion_ctrl_config.position_kd_l>100000000)    motion_ctrl_config.position_kd_l=100000000;
+                if(motion_ctrl_config.position_kd_l>100)    motion_ctrl_config.position_kd_l=100;
                 if(motion_ctrl_config.position_kp_h<0)            motion_ctrl_config.position_kp_h=0;
-                if(motion_ctrl_config.position_kp_h>100000000)    motion_ctrl_config.position_kp_h=100000000;
+                if(motion_ctrl_config.position_kp_h>100)    motion_ctrl_config.position_kp_h=100;
                 if(motion_ctrl_config.position_ki_h<0)            motion_ctrl_config.position_ki_h=0;
-                if(motion_ctrl_config.position_ki_h>100000000)    motion_ctrl_config.position_ki_h=100000000;
+                if(motion_ctrl_config.position_ki_h>100)    motion_ctrl_config.position_ki_h=100;
                 if(motion_ctrl_config.position_kd_h<0)            motion_ctrl_config.position_kd_h=0;
-                if(motion_ctrl_config.position_kd_h>100000000)    motion_ctrl_config.position_kd_h=100000000;
+                if(motion_ctrl_config.position_kd_h>100)    motion_ctrl_config.position_kd_h=100;
                 if(motion_ctrl_config.velocity_kp_l<0)            motion_ctrl_config.velocity_kp_l=0;
-                if(motion_ctrl_config.velocity_kp_l>100000000)    motion_ctrl_config.velocity_kp_l=100000000;
+                if(motion_ctrl_config.velocity_kp_l>100)    motion_ctrl_config.velocity_kp_l=100;
                 if(motion_ctrl_config.velocity_ki_l<0)            motion_ctrl_config.velocity_ki_l=0;
-                if(motion_ctrl_config.velocity_ki_l>100000000)    motion_ctrl_config.velocity_ki_l=100000000;
+                if(motion_ctrl_config.velocity_ki_l>100)    motion_ctrl_config.velocity_ki_l=100;
                 if(motion_ctrl_config.velocity_kd_l<0)            motion_ctrl_config.velocity_kd_l=0;
-                if(motion_ctrl_config.velocity_kd_l>100000000)    motion_ctrl_config.velocity_kd_l=100000000;
+                if(motion_ctrl_config.velocity_kd_l>100)    motion_ctrl_config.velocity_kd_l=100;
                 if(motion_ctrl_config.velocity_kp_h<0)            motion_ctrl_config.velocity_kp_h=0;
-                if(motion_ctrl_config.velocity_kp_h>100000000)    motion_ctrl_config.velocity_kp_h=100000000;
+                if(motion_ctrl_config.velocity_kp_h>100)    motion_ctrl_config.velocity_kp_h=100;
                 if(motion_ctrl_config.velocity_ki_h<0)            motion_ctrl_config.velocity_ki_h=0;
-                if(motion_ctrl_config.velocity_ki_h>100000000)    motion_ctrl_config.velocity_ki_h=100000000;
+                if(motion_ctrl_config.velocity_ki_h>100)    motion_ctrl_config.velocity_ki_h=100;
                 if(motion_ctrl_config.velocity_kd_h<0)            motion_ctrl_config.velocity_kd_h=0;
-                if(motion_ctrl_config.velocity_kd_h>100000000)    motion_ctrl_config.velocity_kd_h=100000000;
+                if(motion_ctrl_config.velocity_kd_h>100)    motion_ctrl_config.velocity_kd_h=100;
                 if(motion_ctrl_config.velocity_lo_l<0)            motion_ctrl_config.velocity_lo_l=0;
                 if(motion_ctrl_config.velocity_lo_l>motion_ctrl_config.max_motor_speed)
                     motion_ctrl_config.velocity_lo_l=motion_ctrl_config.max_motor_speed;


### PR DESCRIPTION
This branch provides:
- gain scheduling feature is tested on Foresight robot
- PID gains are changed from int to float
- removed scaling of PID gains with factor of 1 000 000
- sampling time in controllers used in microseconds
- element of first order next to D part of controller has a filter value equal to 100 instead of 13
- upper limit of gains equal to 100