### PR TITLE
fix the sending of gpio output values to the service

### DIFF
--- a/module_motion_control/src/motion_control_service.xc
+++ b/module_motion_control/src/motion_control_service.xc
@@ -1859,7 +1859,7 @@ void motion_control_service(MotionControlConfig &motion_ctrl_config,
                 break;
         }
 
-        error_detect(i_torque_control.update_upstream_control_data(0), downstream_control_data, i_motion_control);
+        error_detect(i_torque_control.update_upstream_control_data(downstream_control_data.gpio_output), downstream_control_data, i_motion_control);
 
         }
     }


### PR DESCRIPTION
update_upstream_control_data() takes the gpio output value as a parameter
and it was wrongly set to 0 in one call