### PR TITLE
Feature dc100 adc resolution

### DIFF
--- a/module_adc/include/adc_ad7949.h
+++ b/module_adc/include/adc_ad7949.h
@@ -10,7 +10,7 @@
 #include <xclib.h>
 #include <adc_service.h>
 
-
+#define ADC_OUT_MAX_LIMIT   16000   /* ADC can operate till 4V */
 /**
  * @brief Demo service to show how AD7949 can be used.
  *

--- a/module_adc/include/adc_service.h
+++ b/module_adc/include/adc_service.h
@@ -94,7 +94,8 @@ typedef enum {
     WD_OVER_CURRENT_PHASE_C = 3,
     WD_UNDER_VOLTAGE = 4,
     WD_OVER_VOLTAGE = 5,
-    WD_OVER_TEMPERATURE = 6
+    WD_OVER_TEMPERATURE = 6,
+    WD_OVER_ADC_LIMIT = 7
 } WatchdogFaultCode;
 
 /**

--- a/module_adc/src/adc_ad7949.xc
+++ b/module_adc/src/adc_ad7949.xc
@@ -9,7 +9,7 @@
 #include <xclib.h>
 #include <refclk.h>
 #include <adc_ad7949.h>
-
+#include <xscope.h>
 /**
  * @brief Define bit masks to distinguish if a single bit is 0/1 in a 14 bit binary variable.
  */
@@ -311,6 +311,8 @@ void adc_ad7949(
 
     int i_calib_a = 10002, i_calib_b = 10002;
 
+    int adc_out_max_limit = ADC_OUT_MAX_LIMIT;
+
     int data_updated=0;
 
     int dc_value=2617;
@@ -450,6 +452,14 @@ void adc_ad7949(
                     i_watchdog.protect(WD_OVER_VOLTAGE);
                     fault_code=OVER_VOLTAGE_NO_1;
                 }
+
+                if (adc_data_a > adc_out_max_limit || adc_data_b > adc_out_max_limit)
+                {
+                    i_watchdog.protect(WD_OVER_ADC_LIMIT);
+                    fault_code=DEVICE_INTERNAL_CONTINOUS_OVER_CURRENT_NO_1;
+
+                }
+
             }
             I_dc_out=OUT_B[AD_7949_VMOT_DIV_I_MOT];
             analogue_input_a_1 = OUT_A[AD_7949_EXT_A0_N_EXT_A1_N];

--- a/module_adc/src/adc_ad7949.xc
+++ b/module_adc/src/adc_ad7949.xc
@@ -9,7 +9,6 @@
 #include <xclib.h>
 #include <refclk.h>
 #include <adc_ad7949.h>
-#include <xscope.h>
 /**
  * @brief Define bit masks to distinguish if a single bit is 0/1 in a 14 bit binary variable.
  */


### PR DESCRIPTION
- Add Protection limit for ADC maximum value.

- On reaching maximum value, Watchdog is triggered with respective fault code

- ADC can operate till 4V.