### PR TITLE
Fix Hall sensor port config for Drive1000 rev d1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,10 +5,6 @@ sc_sncn_motorcontrol Change Log
 -----
 
   * Renamed board support packages and targets to reflect new product naming conventions
-
-3.1.3
------
-
   * Have three options for switching frequency namely 15 kHz, 30 kHz and 100 kHz
   * Implement new pwm structure with 15 kHz, and use 100 MHz ref_clk_frq with enough flexibility to drive 2 BLDCs and 2 brakes at the same time
   * Add support for DC30 in watchdog service
@@ -16,6 +12,7 @@ sc_sncn_motorcontrol Change Log
   * Measuring units of PID gains have now physical background and their size changed to values related to physical world   
   * Integrate the Drive 100 (DC100) fix from SDK 3.0.4
   * Add reverse sensor polarity command in app_control_tuning
+  * Fix Hall sensor position feedback port config for Drive1000 rev d1
 
 3.1.2
 -----

--- a/module_position_feedback/src/position_feedback_service.xc
+++ b/module_position_feedback/src/position_feedback_service.xc
@@ -174,16 +174,17 @@ void check_ports(port * qei_hall_port_1, port * qei_hall_port_2, port * hall_enc
                     position_feedback_config.sensor_type = 0;
                 } else {
                     configure_in_port(*qei_hall_port_1, spi_ports->spi_interface.blk1);
+                    //if the clock port is GPIO 3, enable the redirect GPIO 3 -> qei_hall_port_1
+                    //by setting P4F2 to high (3rd bit of hall_enc_select_config)
+                    if (position_feedback_config.biss_config.clock_port_config == BISS_CLOCK_PORT_EXT_D3) {
+                        hall_enc_select_config |= 0b0100;
+                    }
                 }
             } else if (position_feedback_config.biss_config.data_port_number == ENCODER_PORT_2) {
                 if (ports_check.qei_hall_port_2 != POSITION_FEEDBACK_PORTS_1) {
                     position_feedback_config.sensor_type = 0;
                 } else {
                     configure_in_port(*qei_hall_port_2, spi_ports->spi_interface.blk1);
-                    //if the clock port is GPIO 3, enable the redirect GPIO 3 -> qei_hall_port_2
-                    if (position_feedback_config.biss_config.clock_port_config == BISS_CLOCK_PORT_EXT_D3) {
-                        hall_enc_select_config |= 0b0100;
-                    }
                 }
             } else if (position_feedback_config.biss_config.data_port_number >= ENCODER_PORT_EXT_D0 && position_feedback_config.biss_config.data_port_number <= ENCODER_PORT_EXT_D3) {
                 //gpio data port


### PR DESCRIPTION
- Switch back the two hall qei ports to match the schematics.
  Only on rev D1
  Port 1 is on the corner of the board.
  It's the port on which BiSS clock can be connected to gpio 3.
  It's controlled by the first bit of hall_enc_select_config.

  Port 2 is port not in the corner.
  BiSS clock is always connected to the fourth bit of hall_enc_select_config.
  It's controlled by the second bit of hall_enc_select_config.

- also group changelog entries of 3.1.3 with 3.2